### PR TITLE
Added countries to sign up

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,8 +122,16 @@ const App: React.FC = () => {
                       <Switch>
                         <Route path={Routes.SIGNUP} exact component={Signup} />
                         <Route path={Routes.LOGIN} exact component={Login} />
-                        <Route path={Routes.FORGOT_PASSWORD_REQUEST} exact component={ForgotPassword} />
-                        <Route path={Routes.FORGOT_PASSWORD_RESET} exact component={ForgotPasswordReset} />
+                        <Route
+                          path={Routes.FORGOT_PASSWORD_REQUEST}
+                          exact
+                          component={ForgotPassword}
+                        />
+                        <Route
+                          path={Routes.FORGOT_PASSWORD_RESET}
+                          exact
+                          component={ForgotPasswordReset}
+                        />
                         <Route
                           path={Routes.VERIFY_EMAIL}
                           exact

--- a/src/auth/authClient.tsx
+++ b/src/auth/authClient.tsx
@@ -76,7 +76,7 @@ const forgotPasswordReset: (
   user: ForgotPasswordResetRequest,
 ) => Promise<void> = (user: ForgotPasswordResetRequest) =>
   AuthAxiosInstance.post(API_ROUTE.FORGOT_PASSWORD_RESET, user);
-  
+
 const verifyEmail: (secretKey: string) => Promise<void> = (secretKey: string) =>
   // eslint-disable-next-line
   AuthAxiosInstance.get(API_ROUTE.VERIFY_EMAIL + secretKey).then(() => {});

--- a/src/auth/ducks/types.ts
+++ b/src/auth/ducks/types.ts
@@ -29,6 +29,7 @@ export interface SignupRequest {
   readonly password: string;
   readonly firstName: string;
   readonly lastName: string;
+  readonly country: string;
 }
 
 export interface ForgotPasswordRequest {

--- a/src/auth/test/authClient.test.ts
+++ b/src/auth/test/authClient.test.ts
@@ -1,6 +1,7 @@
 import { RefreshTokenResponse, TokenPayload } from '../ducks/types';
 import AuthClient, { API_ROUTE } from '../authClient';
 import nock from 'nock';
+import { Countries } from '../../utils/countries';
 
 const BASE_URL = 'http://localhost';
 
@@ -41,6 +42,7 @@ describe('Authentication Client Tests', () => {
         firstName: 'Jack',
         lastName: 'Blanc',
         email: 'jblanc222@gmail.com',
+        country: Countries.DOMINICA,
       });
 
       expect(result).toEqual(response);
@@ -78,7 +80,7 @@ describe('Authentication Client Tests', () => {
 
   describe('Verify Email', () => {
     it('makes the right request', async () => {
-      const secretKey: string = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9';
+      const secretKey = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9';
 
       nock(BASE_URL).get(`${API_ROUTE.VERIFY_EMAIL}${secretKey}`).reply(200);
 
@@ -87,6 +89,6 @@ describe('Authentication Client Tests', () => {
       } catch (e) {
         fail(e);
       }
-    })
-  })
+    });
+  });
 });

--- a/src/auth/test/thunks.test.ts
+++ b/src/auth/test/thunks.test.ts
@@ -3,6 +3,7 @@ import { login, signup } from '../ducks/thunks';
 import { authenticateUser } from '../ducks/actions';
 import authClient from '../authClient';
 import { C4CState, initialStoreState, ThunkExtraArgs } from '../../store';
+import { Countries } from '../../utils/countries';
 
 export const generateState = (partialState: Partial<C4CState>): C4CState => ({
   ...initialStoreState,
@@ -97,6 +98,7 @@ describe('User Authentication Thunks', () => {
         firstName: 'Jack',
         lastName: 'Blanc',
         email: 'jack@jackblanc.com',
+        country: Countries.ST_KITTS_AND_NEVIS,
       })(mockDispatch, getState, mockExtraArgs);
 
       expect(mockDispatch).toHaveBeenCalledTimes(2);
@@ -128,6 +130,7 @@ describe('User Authentication Thunks', () => {
         password: 'password',
         firstName: 'Jack',
         lastName: 'Blanc',
+        country: Countries.ST_LUCIA,
       })(mockDispatch, getState, mockExtraArgs);
 
       expect(mockDispatch).toHaveBeenCalledTimes(2);

--- a/src/containers/signup/index.tsx
+++ b/src/containers/signup/index.tsx
@@ -3,12 +3,19 @@ import { Helmet } from 'react-helmet';
 import { Button, Form, Input, Select, Typography } from 'antd';
 import { Link } from 'react-router-dom';
 import { signup } from '../../auth/ducks/thunks';
-import { connect, useDispatch } from 'react-redux';
+import { connect, useDispatch, useSelector } from 'react-redux';
 import { C4CState } from '../../store';
-import { SignupRequest, UserAuthenticationReducerState } from '../../auth/ducks/types';
+import { useHistory } from 'react-router-dom';
+import {
+  PrivilegeLevel,
+  SignupRequest,
+  UserAuthenticationReducerState,
+} from '../../auth/ducks/types';
 import { AsyncRequestKinds } from '../../utils/asyncRequest';
 import { ContentContainer } from '../../components';
 import { Countries } from '../../utils/countries';
+import { getPrivilegeLevel } from '../../auth/ducks/selectors';
+import { Routes } from '../../App';
 
 const { Title, Paragraph } = Typography;
 
@@ -16,6 +23,14 @@ type SignupProps = UserAuthenticationReducerState;
 
 const Signup: React.FC<SignupProps> = ({ tokens }) => {
   const dispatch = useDispatch();
+  const history = useHistory();
+  const privilegeLevel = useSelector((state: C4CState) =>
+    getPrivilegeLevel(state.authenticationState.tokens),
+  );
+
+  if (privilegeLevel !== PrivilegeLevel.NONE) {
+    history.push(Routes.HOME);
+  }
 
   const onFinish = (values: SignupRequest) => {
     dispatch(

--- a/src/containers/signup/index.tsx
+++ b/src/containers/signup/index.tsx
@@ -24,7 +24,7 @@ type SignupProps = UserAuthenticationReducerState;
 const Signup: React.FC<SignupProps> = ({ tokens }) => {
   const dispatch = useDispatch();
   const history = useHistory();
-  const privilegeLevel = useSelector((state: C4CState) =>
+  const privilegeLevel: PrivilegeLevel = useSelector((state: C4CState) =>
     getPrivilegeLevel(state.authenticationState.tokens),
   );
 

--- a/src/containers/signup/index.tsx
+++ b/src/containers/signup/index.tsx
@@ -39,7 +39,7 @@ const Signup: React.FC<SignupProps> = ({ tokens }) => {
         password: values.password,
         firstName: values.firstName,
         lastName: values.lastName,
-        country: values.country
+        country: values.country,
       }),
     );
   };

--- a/src/containers/signup/index.tsx
+++ b/src/containers/signup/index.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
-import { Button, Form, Input, Typography } from 'antd';
+import { Button, Form, Input, Select, Typography } from 'antd';
 import { Link } from 'react-router-dom';
 import { signup } from '../../auth/ducks/thunks';
 import { connect, useDispatch } from 'react-redux';
 import { C4CState } from '../../store';
-import {
-  SignupRequest,
-  UserAuthenticationReducerState,
-} from '../../auth/ducks/types';
+import { SignupRequest, UserAuthenticationReducerState } from '../../auth/ducks/types';
 import { AsyncRequestKinds } from '../../utils/asyncRequest';
 import { ContentContainer } from '../../components';
+import { Countries } from '../../utils/countries';
 
 const { Title, Paragraph } = Typography;
 
@@ -26,6 +24,7 @@ const Signup: React.FC<SignupProps> = ({ tokens }) => {
         password: values.password,
         firstName: values.firstName,
         lastName: values.lastName,
+        country: values.country
       }),
     );
   };
@@ -85,6 +84,22 @@ const Signup: React.FC<SignupProps> = ({ tokens }) => {
             rules={[{ required: true, message: 'Required' }]}
           >
             <Input.Password />
+          </Form.Item>
+
+          <Form.Item
+            label="Country"
+            name="country"
+            rules={[{ required: true, message: 'Required' }]}
+          >
+            <Select placeholder="Select a country">
+              {(Object.keys(Countries) as (keyof typeof Countries)[]).map(
+                (country) => (
+                  <Select.Option value={country} key={country}>
+                    {Countries[country]}
+                  </Select.Option>
+                ),
+              )}
+            </Select>
           </Form.Item>
 
           <Paragraph>

--- a/src/utils/countries.tsx
+++ b/src/utils/countries.tsx
@@ -1,0 +1,9 @@
+export const Countries = {
+  UNITED_STATES: 'United States',
+  ANTIGUA_AND_BARBUDA: 'Antigua and Barbuda',
+  DOMINICA: 'Dominica',
+  GRENADA: 'Grenada',
+  ST_KITTS_AND_NEVIS: 'St. Kitts and Nevis',
+  ST_LUCIA: 'St. Lucia',
+  ST_VINCENT_AND_THE_GRENADINES: 'St. Vincent and the Grenadines'
+}

--- a/src/utils/countries.tsx
+++ b/src/utils/countries.tsx
@@ -5,5 +5,5 @@ export const Countries = {
   GRENADA: 'Grenada',
   ST_KITTS_AND_NEVIS: 'St. Kitts and Nevis',
   ST_LUCIA: 'St. Lucia',
-  ST_VINCENT_AND_THE_GRENADINES: 'St. Vincent and the Grenadines'
-}
+  ST_VINCENT_AND_THE_GRENADINES: 'St. Vincent and the Grenadines',
+};


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/866744728/pulses/1101260908)

Goal was to get sign up to work by allowing users to select their country. I also added a redirect after successful signup, so signup should fully work now.

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

## This PR

Have hard-coded Countries as a object literal map of country values to human-readable names. These Countries are listed in a new dropdown in the sign up form, which now sends the selected country in the sign up request to the back end. Also added a line to check privilege level from sign up, so the user will automatically be redirected after a successful sign up.

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

## Screenshots
![countries](https://user-images.githubusercontent.com/55663618/110365400-fef27000-8012-11eb-9491-ec762fd6ddac.png)

<!-- Provide screenshots of any new components, styling changes, or pages. --> 

## Verification Steps

Go to localhost:3000/signup. You should now be able to fill out this entire form and press Submit, and you will be redirected to the home page.

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
