### PR TITLE
Add School Directory Search

### DIFF
--- a/src/containers/schoolDirectory/index.tsx
+++ b/src/containers/schoolDirectory/index.tsx
@@ -21,6 +21,7 @@ const { Search } = Input;
 const SchoolDirectory: React.FC = () => {
   const [createSchool, setCreateSchool] = useState<boolean>(false);
   const [updateSchoolList, setUpdateSchoolList] = useState<boolean>(false);
+  const [searchText, setSearchText] = useState<string>("");
   const dispatch = useDispatch();
   const availableSchools: AsyncRequest<SchoolEntry[], any> = useSelector(
     (state: C4CState) => state.selectSchoolState.schools,
@@ -121,7 +122,7 @@ const SchoolDirectory: React.FC = () => {
           </Row>
           <Row gutter={[48, 32]}>
             <Col flex={18}>
-              <Search />
+              <Search onChange={(e) => setSearchText(e.target.value)}/>
             </Col>
             <Col flex={6}>
               <Button onClick={handleOnClickCreateSchool}>Add School</Button>
@@ -131,7 +132,7 @@ const SchoolDirectory: React.FC = () => {
             <Table
               dataSource={
                 availableSchools.kind === AsyncRequestKinds.Completed
-                  ? availableSchools.result
+                  ? availableSchools.result.filter((entry) => entry.name.toLocaleLowerCase().startsWith(searchText.toLowerCase()))
                   : undefined
               }
               columns={columns}


### PR DESCRIPTION
Adds naive table searching. From the search bar input state we manually filter the rows using .startsWith (not case sensitive)

Preferably we would want to use the search from AntD tables, this is just quicker and doesnt remove any components.

## Screenshots

Nothing to search
![image](https://user-images.githubusercontent.com/23691775/119563155-3bfa1300-bd75-11eb-8c70-88b902d41a42.png)

Search with common prefix
![image](https://user-images.githubusercontent.com/23691775/119563223-49af9880-bd75-11eb-82ef-e17044d468ac.png)

Search including some but not all schools
![image](https://user-images.githubusercontent.com/23691775/119563260-5207d380-bd75-11eb-8a67-35fb441d39bf.png)

Search excluding all schools:
![image](https://user-images.githubusercontent.com/23691775/119563291-5a600e80-bd75-11eb-936a-d030f4ba96e4.png)
