### PR TITLE
Fix Apprenticeship Button Highlighting

### DIFF
--- a/src/containers/library-report/ReportWithLibrary.tsx
+++ b/src/containers/library-report/ReportWithLibrary.tsx
@@ -91,6 +91,7 @@ const ReportWithLibrary: React.FC = () => {
             note={
               'Does this school have a known apprenticeship program in the library?'
             }
+            name="ignore"
           >
             {hasApprenticeship && (
               <FormItemDropdown


### PR DESCRIPTION
## Why

https://code4community-team.monday.com/boards/866744728/pulses/1290330401?notification=931245763

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

## This PR

Adds the button highlight to this button.

NOTE: In order to highlight the button it needs a "name", (I chose "ignore") this field will appear in the JSON output of the form. Currently the report endpoint doesnt exist so this isn't a problem. Although in the future this field may need to be ignored on the backend or filtered out on the frontend.

## Screenshots

![image](https://user-images.githubusercontent.com/23691775/119568642-b332a580-bd7b-11eb-99eb-a9dd7bb7ac89.png)

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
