### PR TITLE
Add Past Reports List View

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,8 @@ import SchoolInformation from './containers/schoolInfo';
 import LibraryReport from './containers/library-report/LibraryReport';
 import SchoolContacts from './containers/schoolContact';
 import FormSubmission from './containers/formSubmission';
+import PastSubmissionsSchools from './containers/pastSubmissionsSchools/PastSubmissionsSchools';
+import PastSubmissionReports from './containers/pastSubmissionsReports/PastSubmissionReports';
 
 const { Content } = Layout;
 
@@ -50,9 +52,10 @@ export enum Routes {
   FORGOT_PASSWORD_REQUEST = '/forgot-password',
   FORGOT_PASSWORD_RESET = '/forgot-password-reset/:key',
   VERIFY_EMAIL = '/verify/:key',
-  TODO = '/TODO',
   SCHOOL_DIRECTORY = '/school-directory',
   USER_DIRECTORY = '/user-directory',
+  PAST_SUBMISSIONS_SCHOOLS = '/past-submissions-schools',
+  PAST_SUBMISSIONS_REPORTS = '/past-submissions-reports',
 }
 
 const App: React.FC = () => {
@@ -124,6 +127,16 @@ const App: React.FC = () => {
                           exact
                           component={FormSubmission}
                         />
+                        <Route
+                          path={Routes.PAST_SUBMISSIONS_SCHOOLS}
+                          exact
+                          component={PastSubmissionsSchools}
+                        />
+                        <Route
+                          path={Routes.PAST_SUBMISSIONS_REPORTS}
+                          exact
+                          component={PastSubmissionReports}
+                        />
                         <Route path={Routes.LOGIN} exact component={Login} />
                         <Route path={Routes.SIGNUP} exact component={Signup} />
                         <Route
@@ -167,6 +180,16 @@ const App: React.FC = () => {
                           path={Routes.FORM_SUB_CONFIRMATION}
                           exact
                           component={FormSubmission}
+                        />
+                        <Route
+                          path={Routes.PAST_SUBMISSIONS_SCHOOLS}
+                          exact
+                          component={PastSubmissionsSchools}
+                        />
+                        <Route
+                          path={Routes.PAST_SUBMISSIONS_REPORTS}
+                          exact
+                          component={PastSubmissionReports}
                         />
                         <Route path={Routes.LOGIN} exact component={Login} />
                         <Route path={Routes.SIGNUP} exact component={Signup} />

--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -18,6 +18,8 @@ import {
   ReportWithoutLibraryRequest,
 } from '../containers/library-report/ducks/types';
 import { GetUserResponse } from '../containers/settings/ducks/types';
+import { PastSubmissionsSchoolsResponse } from '../containers/pastSubmissionsSchools/ducks/types';
+import { ReportGenericListResponse } from '../containers/pastSubmissionsReports/ducks/types';
 
 export interface ApiExtraArgs {
   readonly protectedApiClient: ProtectedApiClient;
@@ -93,6 +95,13 @@ export interface ProtectedApiClient {
   ) => Promise<LibraryReportResponse>;
 
   readonly getAllSchools: () => Promise<SchoolEntry[]>;
+
+  readonly getPastSubmissionSchools: () => Promise<PastSubmissionsSchoolsResponse>;
+
+  readonly getPastSubmissionReports: (
+    schoolId: number,
+    page: number,
+  ) => Promise<ReportGenericListResponse>;
 }
 
 export enum ProtectedApiClientRoutes {
@@ -101,8 +110,8 @@ export enum ProtectedApiClientRoutes {
   SCHOOLS = '/api/v1/protected/schools',
   SCHOOL_CONTACTS = '/api/v1/protected/schools/:school_id/contacts',
   LIBRARY_REPORTS = '/api/v1/protected/schools/:school_id/reports',
-  REPORT_WITH_LIBRARY = '/api/v1/protected/schools/:school_id/reports',
   BOOK_REPORTS = '/api/v1/protected/schools/:school_id/books',
+  PAST_SUBMISSIONS_SCHOOLS = '/api/v1/protected/schools/reports/users',
 }
 
 export type WithCount<T> = T & {
@@ -320,6 +329,31 @@ const getAllSchools = (): Promise<SchoolEntry[]> => {
     .catch((err) => err);
 };
 
+const getPastSubmissionSchools = (): Promise<PastSubmissionsSchoolsResponse> => {
+  return AppAxiosInstance.get(ProtectedApiClientRoutes.PAST_SUBMISSIONS_SCHOOLS)
+    .then((res) => res.data)
+    .catch((err) => err);
+};
+
+const getPastSubmissionReports = (
+  schoolId: number,
+  page = 1,
+): Promise<ReportGenericListResponse> => {
+  return AppAxiosInstance.get(
+    ProtectedApiClientRoutes.LIBRARY_REPORTS.replace(
+      ':school_id',
+      schoolId.toString(),
+    ),
+    {
+      params: {
+        p: page,
+      },
+    },
+  )
+    .then((res) => res.data)
+    .catch((err) => err);
+};
+
 const Client: ProtectedApiClient = Object.freeze({
   changePassword,
   createSchool,
@@ -340,6 +374,8 @@ const Client: ProtectedApiClient = Object.freeze({
   getLatestReport,
   createReportWithLibrary,
   createReportWithoutLibrary,
+  getPastSubmissionSchools,
+  getPastSubmissionReports,
 });
 
 export default Client;

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Spin } from 'antd';
+import FormContentContainer from './form-style/FormContentContainer';
+import FormContainer from './form-style/FormContainer';
+
+interface LoadingProps {
+  title: string;
+}
+
+const Loading: React.FC<LoadingProps> = (props) => {
+  return (
+    <FormContentContainer title={props.title}>
+      <FormContainer title={''}>
+        <Spin size={'large'} />
+      </FormContainer>
+    </FormContentContainer>
+  );
+};
+
+export default Loading;

--- a/src/components/form-style/FormContentContainer.tsx
+++ b/src/components/form-style/FormContentContainer.tsx
@@ -7,6 +7,7 @@ interface FormContentContainerProps {
   // used when the NO flow is selected to
   // prevent further form filling out
   readonly disableLastTwo?: boolean;
+  readonly title?: string;
 }
 
 const { Title } = Typography;
@@ -26,7 +27,9 @@ const FormContentContainer: React.FC<FormContentContainerProps> = (props) => {
     <ContentContainer>
       <Row gutter={[0, 32]}>
         <Col flex={24}>
-          <FormTitle level={2}>Library Monitoring Form</FormTitle>
+          <FormTitle level={2}>
+            {props.title || 'Library Monitoring Form'}
+          </FormTitle>
         </Col>
       </Row>
       <Row>

--- a/src/containers/home/index.tsx
+++ b/src/containers/home/index.tsx
@@ -223,7 +223,7 @@ const Home: React.FC = () => {
                 <InContain
                   lastPiece
                   onClick={() => {
-                    history.push(Routes.SETTINGS);
+                    history.push(Routes.PAST_SUBMISSIONS_SCHOOLS);
                   }}
                 >
                   <Row>

--- a/src/containers/library-report/ducks/types.ts
+++ b/src/containers/library-report/ducks/types.ts
@@ -16,7 +16,7 @@ export interface LibraryReportReducerState {
   readonly isYesReport?: boolean;
 }
 
-interface LibraryReportShared {
+export interface LibraryReportShared {
   readonly numberOfChildren: null | number;
   readonly numberOfBooks: null | number;
   readonly mostRecentShipmentYear: null | number;

--- a/src/containers/pastSubmissionsReports/PastSubmissionReports.tsx
+++ b/src/containers/pastSubmissionsReports/PastSubmissionReports.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from 'react';
+import { Container, Outer } from '../../components/form-style/FormContainer';
+import { Col, Row, Table } from 'antd';
+import { ColumnType } from 'antd/lib/table';
+import { DirectoryTitle } from '../../components';
+import { useDispatch, useSelector } from 'react-redux';
+import { AsyncRequest, AsyncRequestKinds } from '../../utils/asyncRequest';
+import { C4CState } from '../../store';
+import { getPastSubmissionsReports } from './ducks/thunks';
+import { useHistory } from 'react-router-dom';
+import { Routes } from '../../App';
+import { LibraryReportResponse } from '../library-report/ducks/types';
+import { PastSubmissionsSchoolsReducerState } from '../pastSubmissionsSchools/ducks/types';
+import Loading from '../../components/Loading';
+import { ReportGenericListResponse } from './ducks/types';
+const PastSubmissionsReports: React.FC = () => {
+  const dispatch = useDispatch();
+  const history = useHistory();
+
+  const [currentPage, setCurrentPage] = useState<number>(1);
+
+  const schoolId: PastSubmissionsSchoolsReducerState['pastSubmissionSelectedSchoolId'] = useSelector(
+    (state: C4CState) =>
+      state.pastSubmissionSchoolsState.pastSubmissionSelectedSchoolId,
+  );
+
+  useEffect(() => {
+    if (schoolId !== undefined) {
+      dispatch(getPastSubmissionsReports(schoolId, 1));
+    } else {
+      history.push(Routes.PAST_SUBMISSIONS_SCHOOLS);
+    }
+  }, [schoolId, dispatch, history]);
+
+  const availableReports: AsyncRequest<
+    ReportGenericListResponse,
+    any
+  > = useSelector(
+    (state: C4CState) =>
+      state.pastSubmissionReportsState.pastSubmissionsReports,
+  );
+
+  const columns: ColumnType<LibraryReportResponse>[] = [
+    {
+      title: 'Last Updated',
+      dataIndex: 'updatedAt',
+      key: 'id',
+      sorter: {
+        compare: (a, b) => a.updatedAt.localeCompare(b.updatedAt),
+        multiple: 1,
+      },
+    },
+    {
+      title: 'Library Status',
+      dataIndex: 'libraryStatus',
+      key: 'id',
+      sorter: {
+        compare: (a, b) => a.libraryStatus.localeCompare(b.libraryStatus),
+        multiple: 1,
+      },
+    },
+    {
+      title: 'School ID',
+      dataIndex: 'schoolId',
+      key: 'id',
+    },
+    {
+      title: 'User ID',
+      dataIndex: 'userId',
+      key: 'id',
+      sorter: {
+        compare: (a, b) =>
+          a.userId.toString().localeCompare(b.userId.toString()),
+        multiple: 1,
+      },
+    },
+  ];
+
+  const onPageChange = (page: any, pageSize: any) => {
+    if (page !== currentPage && schoolId !== undefined && page !== undefined) {
+      dispatch(getPastSubmissionsReports(schoolId, page));
+      setCurrentPage(page);
+    }
+  };
+
+  switch (availableReports.kind) {
+    case AsyncRequestKinds.NotStarted:
+    case AsyncRequestKinds.Failed:
+      return <p>An error occurred loading past submissions</p>;
+    case AsyncRequestKinds.Loading:
+      return <Loading title={'Past Submissions'} />;
+    case AsyncRequestKinds.Completed:
+      return (
+        <Container>
+          <Row gutter={[0, 32]}>
+            <Col flex={24}>
+              <DirectoryTitle level={2}>Past Submissions</DirectoryTitle>
+            </Col>
+          </Row>
+          <Outer>
+            <Table
+              dataSource={availableReports.result.reports || []}
+              columns={columns}
+              pagination={{
+                current: currentPage,
+                total: availableReports.result.count,
+                pageSize: 10,
+                onChange: onPageChange,
+              }}
+            />
+          </Outer>
+        </Container>
+      );
+  }
+};
+
+export default PastSubmissionsReports;

--- a/src/containers/pastSubmissionsReports/PastSubmissionReports.tsx
+++ b/src/containers/pastSubmissionsReports/PastSubmissionReports.tsx
@@ -44,7 +44,6 @@ const PastSubmissionsReports: React.FC = () => {
     {
       title: 'Last Updated',
       dataIndex: 'updatedAt',
-      key: 'id',
       sorter: {
         compare: (a, b) => a.updatedAt.localeCompare(b.updatedAt),
         multiple: 1,
@@ -53,7 +52,6 @@ const PastSubmissionsReports: React.FC = () => {
     {
       title: 'Library Status',
       dataIndex: 'libraryStatus',
-      key: 'id',
       sorter: {
         compare: (a, b) => a.libraryStatus.localeCompare(b.libraryStatus),
         multiple: 1,
@@ -62,15 +60,12 @@ const PastSubmissionsReports: React.FC = () => {
     {
       title: 'School ID',
       dataIndex: 'schoolId',
-      key: 'id',
     },
     {
       title: 'User ID',
       dataIndex: 'userId',
-      key: 'id',
       sorter: {
-        compare: (a, b) =>
-          a.userId.toString().localeCompare(b.userId.toString()),
+        compare: (a, b) => (a.userId > b.userId ? 1 : -1),
         multiple: 1,
       },
     },

--- a/src/containers/pastSubmissionsReports/ducks/actions.ts
+++ b/src/containers/pastSubmissionsReports/ducks/actions.ts
@@ -1,0 +1,12 @@
+import { genericAsyncActions } from '../../../utils/asyncRequest';
+import { ReportGenericListResponse } from './types';
+
+export const pastSubmissionsReports = genericAsyncActions<
+  ReportGenericListResponse,
+  any
+>();
+
+export type PastSubmissionsReportsActions =
+  | ReturnType<typeof pastSubmissionsReports.loading>
+  | ReturnType<typeof pastSubmissionsReports.loaded>
+  | ReturnType<typeof pastSubmissionsReports.failed>;

--- a/src/containers/pastSubmissionsReports/ducks/reducers.ts
+++ b/src/containers/pastSubmissionsReports/ducks/reducers.ts
@@ -1,0 +1,45 @@
+import {
+  ASYNC_REQUEST_FAILED_ACTION,
+  ASYNC_REQUEST_LOADED_ACTION,
+  ASYNC_REQUEST_LOADING_ACTION,
+  AsyncRequestNotStarted,
+  generateAsyncRequestReducer,
+} from '../../../utils/asyncRequest';
+import { C4CAction } from '../../../store';
+import {
+  PastSubmissionsReportsReducerState,
+  ReportGenericListResponse,
+} from './types';
+import { pastSubmissionsReports } from './actions';
+
+export const initialPastSubmissionsReports: PastSubmissionsReportsReducerState = {
+  pastSubmissionsReports: AsyncRequestNotStarted<ReportGenericListResponse>(),
+};
+
+const pastSubmissionsReportsReducer = generateAsyncRequestReducer<
+  PastSubmissionsReportsReducerState,
+  ReportGenericListResponse,
+  void
+>(pastSubmissionsReports.key);
+
+const reducers = (
+  state: PastSubmissionsReportsReducerState = initialPastSubmissionsReports,
+  action: C4CAction,
+): PastSubmissionsReportsReducerState => {
+  switch (action.type) {
+    case ASYNC_REQUEST_LOADING_ACTION:
+    case ASYNC_REQUEST_LOADED_ACTION:
+    case ASYNC_REQUEST_FAILED_ACTION:
+      return {
+        ...state,
+        pastSubmissionsReports: pastSubmissionsReportsReducer(
+          state.pastSubmissionsReports,
+          action,
+        ),
+      };
+    default:
+      return state;
+  }
+};
+
+export default reducers;

--- a/src/containers/pastSubmissionsReports/ducks/thunks.ts
+++ b/src/containers/pastSubmissionsReports/ducks/thunks.ts
@@ -1,0 +1,19 @@
+import { PastSubmissionsReportsThunkAction } from './types';
+import { pastSubmissionsReports } from './actions';
+
+export const getPastSubmissionsReports = (
+  schoolId: number,
+  page: number,
+): PastSubmissionsReportsThunkAction<void> => {
+  return (dispatch, getState, { protectedApiClient }): Promise<void> => {
+    dispatch(pastSubmissionsReports.loading());
+    return protectedApiClient
+      .getPastSubmissionReports(schoolId, page)
+      .then((response) => {
+        dispatch(pastSubmissionsReports.loaded(response));
+      })
+      .catch((error) => {
+        dispatch(pastSubmissionsReports.failed(error.response.data));
+      });
+  };
+};

--- a/src/containers/pastSubmissionsReports/ducks/types.ts
+++ b/src/containers/pastSubmissionsReports/ducks/types.ts
@@ -1,0 +1,22 @@
+import { ThunkAction } from 'redux-thunk';
+import { C4CState } from '../../../store';
+import { ApiExtraArgs } from '../../../api/protectedApiClient';
+import { PastSubmissionsReportsActions } from './actions';
+import { AsyncRequest } from '../../../utils/asyncRequest';
+import { LibraryReportResponse } from '../../library-report/ducks/types';
+
+export type PastSubmissionsReportsThunkAction<R> = ThunkAction<
+  R,
+  C4CState,
+  ApiExtraArgs,
+  PastSubmissionsReportsActions
+>;
+
+export interface PastSubmissionsReportsReducerState {
+  readonly pastSubmissionsReports: AsyncRequest<ReportGenericListResponse>;
+}
+
+export interface ReportGenericListResponse {
+  count: number;
+  reports: LibraryReportResponse[];
+}

--- a/src/containers/pastSubmissionsSchools/PastSubmissionsSchools.tsx
+++ b/src/containers/pastSubmissionsSchools/PastSubmissionsSchools.tsx
@@ -1,51 +1,60 @@
 import React, { useEffect, useState } from 'react';
-import { Col, Form, Row, Select } from 'antd';
 import FormContainer from '../../components/form-style/FormContainer';
-import FormPiece from '../../components/form-style/FormPiece';
-import FormContentContainer from '../../components/form-style/FormContentContainer';
+import { Col, Form, Row, Select } from 'antd';
 import { useDispatch, useSelector } from 'react-redux';
-import { loadSchools } from './ducks/thunks';
-import { SchoolEntry } from './ducks/types';
-import { selectSchoolId } from './ducks/actions';
-import { useHistory } from 'react-router';
-import { Routes } from '../../App';
-import { C4CState } from '../../store';
 import { AsyncRequest, AsyncRequestKinds } from '../../utils/asyncRequest';
+import { C4CState } from '../../store';
+import { getPastSubmissionsSchools } from './ducks/thunks';
+import {
+  PastSubmissionsSchoolsResponse,
+  SchoolSummaryResponse,
+} from './ducks/types';
+import FormContentContainer from '../../components/form-style/FormContentContainer';
+import FormPiece from '../../components/form-style/FormPiece';
 import FormButtons from '../../components/form-style/FormButtons';
+import Loading from '../../components/Loading';
+import { setPastSubmissionsSchoolId } from './ducks/actions';
+import { Routes } from '../../App';
+import { useHistory } from 'react-router';
 
-interface SelectSchoolForm {
-  schoolId: number;
+interface SelectPasSubmissionSchoolForm {
+  pastSubmissionsSchoolId: number;
 }
 
-const SelectSchool: React.FC = () => {
+const PastSubmissionsSchools: React.FC = (props) => {
   const dispatch = useDispatch();
-  const availableSchools: AsyncRequest<SchoolEntry[], any> = useSelector(
-    (state: C4CState) => state.selectSchoolState.schools,
-  );
   const history = useHistory();
-  const [formValues, setFormValues] = useState({} as any);
+
+  const availableSchools: AsyncRequest<
+    PastSubmissionsSchoolsResponse,
+    any
+  > = useSelector(
+    (state: C4CState) =>
+      state.pastSubmissionSchoolsState.pastSubmissionsSchools,
+  );
 
   useEffect(() => {
-    dispatch(loadSchools());
+    dispatch(getPastSubmissionsSchools());
   }, [dispatch]);
 
-  const submitDisabled = !formValues.schoolId;
-
-  const handleSubmit = (values: SelectSchoolForm) => {
-    dispatch(selectSchoolId(values.schoolId));
-    history.push(Routes.SCHOOL_INFO);
-  };
-
-  const renderSchoolOption = (school: SchoolEntry) => (
+  const renderSchoolOption = (school: SchoolSummaryResponse) => (
     <Select.Option value={school.id}>{school.name}</Select.Option>
   );
 
+  const handleSubmit = (values: SelectPasSubmissionSchoolForm) => {
+    dispatch(setPastSubmissionsSchoolId(values.pastSubmissionsSchoolId));
+    history.push(Routes.PAST_SUBMISSIONS_REPORTS);
+  };
+
+  const [formValues, setFormValues] = useState({} as any);
+  const submitDisabled = !formValues.pastSubmissionsSchoolId;
+
   switch (availableSchools.kind) {
     case AsyncRequestKinds.NotStarted:
-    case AsyncRequestKinds.Loading:
-      return <p>Loading schools...</p>;
     case AsyncRequestKinds.Failed:
-      return <p>An error occurred loading schools</p>;
+      return <p>An error occurred loading past submissions</p>;
+    case AsyncRequestKinds.Loading:
+      return <Loading title={'Past Submissions'} />;
     case AsyncRequestKinds.Completed:
       return (
         <FormContentContainer>
@@ -57,8 +66,11 @@ const SelectSchool: React.FC = () => {
             <FormContainer title="Select a School">
               <Row gutter={[0, 0]}>
                 <Col flex={24}>
-                  <FormPiece note="Which school will you be monitoring today?">
-                    <Form.Item name="schoolId" rules={[{ required: true }]}>
+                  <FormPiece note="Which school would you like to see past reports of?">
+                    <Form.Item
+                      name="pastSubmissionsSchoolId"
+                      rules={[{ required: true }]}
+                    >
                       <Select
                         placeholder="Select a school"
                         showSearch
@@ -74,7 +86,7 @@ const SelectSchool: React.FC = () => {
                             .localeCompare(optionB.children.toLowerCase())
                         }
                       >
-                        {Array.from(availableSchools.result).map(
+                        {Array.from(availableSchools.result.schools).map(
                           renderSchoolOption,
                         )}
                       </Select>
@@ -97,4 +109,4 @@ const SelectSchool: React.FC = () => {
   }
 };
 
-export default SelectSchool;
+export default PastSubmissionsSchools;

--- a/src/containers/pastSubmissionsSchools/ducks/actions.ts
+++ b/src/containers/pastSubmissionsSchools/ducks/actions.ts
@@ -1,0 +1,24 @@
+import { genericAsyncActions } from '../../../utils/asyncRequest';
+import { PastSubmissionsSchoolsResponse } from './types';
+import { Action } from '../../../store';
+import { LibraryReportResponse } from '../../library-report/ducks/types';
+
+export const pastSubmissionsSchools = genericAsyncActions<
+  PastSubmissionsSchoolsResponse,
+  any
+>();
+
+export type PastSubmissionsSchoolsActions =
+  | ReturnType<typeof setPastSubmissionsSchoolId>
+  | ReturnType<typeof pastSubmissionsSchools.loading>
+  | ReturnType<typeof pastSubmissionsSchools.loaded>
+  | ReturnType<typeof pastSubmissionsSchools.failed>;
+
+export const SET_PAST_SUBMISSIONS_SCHOOL_ID = 'setPastSubmissionsSchoolId';
+
+export const setPastSubmissionsSchoolId = (
+  schoolId?: number,
+): Action<typeof SET_PAST_SUBMISSIONS_SCHOOL_ID, number | undefined> => ({
+  type: SET_PAST_SUBMISSIONS_SCHOOL_ID,
+  payload: schoolId,
+});

--- a/src/containers/pastSubmissionsSchools/ducks/actions.ts
+++ b/src/containers/pastSubmissionsSchools/ducks/actions.ts
@@ -1,7 +1,6 @@
 import { genericAsyncActions } from '../../../utils/asyncRequest';
 import { PastSubmissionsSchoolsResponse } from './types';
 import { Action } from '../../../store';
-import { LibraryReportResponse } from '../../library-report/ducks/types';
 
 export const pastSubmissionsSchools = genericAsyncActions<
   PastSubmissionsSchoolsResponse,

--- a/src/containers/pastSubmissionsSchools/ducks/reducers.ts
+++ b/src/containers/pastSubmissionsSchools/ducks/reducers.ts
@@ -1,0 +1,53 @@
+import {
+  ASYNC_REQUEST_FAILED_ACTION,
+  ASYNC_REQUEST_LOADED_ACTION,
+  ASYNC_REQUEST_LOADING_ACTION,
+  AsyncRequestNotStarted,
+  generateAsyncRequestReducer,
+} from '../../../utils/asyncRequest';
+import { C4CAction } from '../../../store';
+import {
+  PastSubmissionsSchoolsReducerState,
+  PastSubmissionsSchoolsResponse,
+} from './types';
+import {
+  pastSubmissionsSchools,
+  SET_PAST_SUBMISSIONS_SCHOOL_ID,
+} from './actions';
+
+export const initialPastSubmissionsSchools: PastSubmissionsSchoolsReducerState = {
+  pastSubmissionsSchools: AsyncRequestNotStarted<PastSubmissionsSchoolsResponse>(),
+};
+
+const pastSubmissionsSchoolsReducer = generateAsyncRequestReducer<
+  PastSubmissionsSchoolsReducerState,
+  PastSubmissionsSchoolsResponse,
+  void
+>(pastSubmissionsSchools.key);
+
+const reducers = (
+  state: PastSubmissionsSchoolsReducerState = initialPastSubmissionsSchools,
+  action: C4CAction,
+): PastSubmissionsSchoolsReducerState => {
+  switch (action.type) {
+    case ASYNC_REQUEST_LOADING_ACTION:
+    case ASYNC_REQUEST_LOADED_ACTION:
+    case ASYNC_REQUEST_FAILED_ACTION:
+      return {
+        ...state,
+        pastSubmissionsSchools: pastSubmissionsSchoolsReducer(
+          state.pastSubmissionsSchools,
+          action,
+        ),
+      };
+    case SET_PAST_SUBMISSIONS_SCHOOL_ID:
+      return {
+        ...state,
+        pastSubmissionSelectedSchoolId: action.payload,
+      };
+    default:
+      return state;
+  }
+};
+
+export default reducers;

--- a/src/containers/pastSubmissionsSchools/ducks/thunks.ts
+++ b/src/containers/pastSubmissionsSchools/ducks/thunks.ts
@@ -1,0 +1,16 @@
+import { PastSubmissionsThunkAction } from './types';
+import { pastSubmissionsSchools } from './actions';
+
+export const getPastSubmissionsSchools = (): PastSubmissionsThunkAction<void> => {
+  return (dispatch, getState, { protectedApiClient }): Promise<void> => {
+    dispatch(pastSubmissionsSchools.loading());
+    return protectedApiClient
+      .getPastSubmissionSchools()
+      .then((response) => {
+        dispatch(pastSubmissionsSchools.loaded(response));
+      })
+      .catch((error) => {
+        dispatch(pastSubmissionsSchools.failed(error.response.data));
+      });
+  };
+};

--- a/src/containers/pastSubmissionsSchools/ducks/types.ts
+++ b/src/containers/pastSubmissionsSchools/ducks/types.ts
@@ -1,0 +1,28 @@
+import { ThunkAction } from 'redux-thunk';
+import { C4CState } from '../../../store';
+import { ApiExtraArgs } from '../../../api/protectedApiClient';
+import { PastSubmissionsSchoolsActions } from './actions';
+import { AsyncRequest } from '../../../utils/asyncRequest';
+
+export type PastSubmissionsThunkAction<R> = ThunkAction<
+  R,
+  C4CState,
+  ApiExtraArgs,
+  PastSubmissionsSchoolsActions
+>;
+
+export interface PastSubmissionsSchoolsReducerState {
+  readonly pastSubmissionsSchools: AsyncRequest<PastSubmissionsSchoolsResponse>;
+  readonly pastSubmissionSelectedSchoolId?: number;
+}
+
+export type PastSubmissionsSchoolsResponse = {
+  readonly count: number;
+  readonly schools: SchoolSummaryResponse[];
+};
+
+export type SchoolSummaryResponse = {
+  readonly id: number;
+  readonly name: string;
+  readonly country: string;
+};

--- a/src/store.ts
+++ b/src/store.ts
@@ -43,6 +43,16 @@ import { BookLogsReducerState } from './containers/bookLogs/ducks/types';
 import bookLogsReducer, {
   initialBookLogsState,
 } from './containers/bookLogs/ducks/reducers';
+import pastSubmissionsSchoolsReducer, {
+  initialPastSubmissionsSchools,
+} from './containers/pastSubmissionsSchools/ducks/reducers';
+import pastSubmissionsReportsReducer, {
+  initialPastSubmissionsReports,
+} from './containers/pastSubmissionsReports/ducks/reducers';
+
+import { PastSubmissionsSchoolsReducerState } from './containers/pastSubmissionsSchools/ducks/types';
+import { PastSubmissionsSchoolsActions } from './containers/pastSubmissionsSchools/ducks/actions';
+import { PastSubmissionsReportsReducerState } from './containers/pastSubmissionsReports/ducks/types';
 
 export interface C4CState {
   authenticationState: UserAuthenticationReducerState;
@@ -51,6 +61,8 @@ export interface C4CState {
   bookLogsState: BookLogsReducerState;
   selectSchoolState: SelectSchoolReducerState;
   libraryReportState: LibraryReportReducerState;
+  pastSubmissionSchoolsState: PastSubmissionsSchoolsReducerState;
+  pastSubmissionReportsState: PastSubmissionsReportsReducerState;
 }
 
 export interface Action<T, P> {
@@ -64,7 +76,8 @@ export type C4CAction =
   | LibraryReportActions
   | SchoolInformationActions
   | BookLogsActions
-  | SelectSchoolActions;
+  | SelectSchoolActions
+  | PastSubmissionsSchoolsActions;
 
 export type ThunkExtraArgs = UserAuthenticationExtraArgs & ApiExtraArgs;
 
@@ -75,6 +88,8 @@ const reducers = combineReducers<C4CState, C4CAction>({
   libraryReportState: libraryReportReducer,
   bookLogsState: bookLogsReducer,
   selectSchoolState: selectSchoolReducer,
+  pastSubmissionSchoolsState: pastSubmissionsSchoolsReducer,
+  pastSubmissionReportsState: pastSubmissionsReportsReducer,
 });
 
 export const initialStoreState: C4CState = {
@@ -84,6 +99,8 @@ export const initialStoreState: C4CState = {
   libraryReportState: initialLibraryReportState,
   bookLogsState: initialBookLogsState,
   selectSchoolState: initialSelectSchoolState,
+  pastSubmissionSchoolsState: initialPastSubmissionsSchools,
+  pastSubmissionReportsState: initialPastSubmissionsReports,
 };
 
 export const LOCALSTORAGE_STATE_KEY = 'state';


### PR DESCRIPTION
Adds the past reports list view:
 - Shows dropdown select list of all schools the current user 
 - After selecting a school, the list of reports is shown

<!-- Provide screenshots of any new components, styling changes, or pages. --> 

<img width="1348" alt="Screen Shot 2021-07-01 at 7 01 26 PM" src="https://user-images.githubusercontent.com/32231130/124198494-c7667280-da9e-11eb-8919-316f94db9a53.png">

<img width="1424" alt="Screen Shot 2021-07-01 at 7 01 52 PM" src="https://user-images.githubusercontent.com/32231130/124198524-d4836180-da9e-11eb-812b-2cf96ab25ee6.png">

<img width="1160" alt="Screen Shot 2021-07-01 at 7 02 23 PM" src="https://user-images.githubusercontent.com/32231130/124198557-e6650480-da9e-11eb-9432-229a7ee1d5dc.png">

<img width="1442" alt="Screen Shot 2021-07-01 at 7 02 28 PM" src="https://user-images.githubusercontent.com/32231130/124198571-ee24a900-da9e-11eb-936b-f3de316b2a5d.png">
