### PR TITLE
'Select a School' form filters by the user's country 

### DIFF
--- a/src/containers/selectSchool/SelectSchool.tsx
+++ b/src/containers/selectSchool/SelectSchool.tsx
@@ -67,7 +67,7 @@ const SelectSchool: React.FC = () => {
       if (Object.keys(userInfo).length === 0) {
         return <p>Loading schools...</p>;
       }
-      let schoolsInCountry = availableSchools.result.filter((school) => school.country === userInfo.country);
+      const schoolsInCountry = availableSchools.result.filter((school) => school.country === userInfo.country);
       return (
         <FormContentContainer>
           <Form

--- a/src/containers/selectSchool/SelectSchool.tsx
+++ b/src/containers/selectSchool/SelectSchool.tsx
@@ -12,6 +12,10 @@ import { Routes } from '../../App';
 import { C4CState } from '../../store';
 import { AsyncRequest, AsyncRequestKinds } from '../../utils/asyncRequest';
 import FormButtons from '../../components/form-style/FormButtons';
+import { GetUserResponse } from '../settings/ducks/types';
+import ProtectedApiClient from '../../api/protectedApiClient';
+import { getUserID } from '../../auth/ducks/selectors';
+
 
 interface SelectSchoolForm {
   schoolId: number;
@@ -24,10 +28,23 @@ const SelectSchool: React.FC = () => {
   );
   const history = useHistory();
   const [formValues, setFormValues] = useState({} as any);
+  const [userInfo, setUserInfo] = useState<GetUserResponse>(
+    {} as GetUserResponse,
+  );
+  const userId = useSelector((state: C4CState) => {
+    return getUserID(state.authenticationState.tokens);
+  });
+  
 
   useEffect(() => {
     dispatch(loadSchools());
   }, [dispatch]);
+
+  useEffect(() => {
+    ProtectedApiClient.getUser()
+      .then(setUserInfo)
+      .catch((e) => e);
+  }, [userId]);
 
   const submitDisabled = !formValues.schoolId;
 
@@ -47,6 +64,10 @@ const SelectSchool: React.FC = () => {
     case AsyncRequestKinds.Failed:
       return <p>An error occurred loading schools</p>;
     case AsyncRequestKinds.Completed:
+      if (Object.keys(userInfo).length === 0) {
+        return <p>Loading schools...</p>;
+      }
+      let schoolsInCountry = availableSchools.result.filter((school) => school.country === userInfo.country);
       return (
         <FormContentContainer>
           <Form
@@ -74,7 +95,7 @@ const SelectSchool: React.FC = () => {
                             .localeCompare(optionB.children.toLowerCase())
                         }
                       >
-                        {Array.from(availableSchools.result).map(
+                        {Array.from(schoolsInCountry).map(
                           renderSchoolOption,
                         )}
                       </Select>


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/866744728/pulses/1345337034)


<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

The 'Select a School' form now will only display the schools in the user's country. 

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

I pulled in the user's information in the 'SelectSchool' component and then based on that filtered the list down to just the schools in that user's country. I also added a check right before that to ensure that the user's country was being loaded before the dropdown list is displayed (so the list can actually be filtered correctly). 

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 

<img width="1432" alt="Screen Shot 2021-07-05 at 10 52 07 PM" src="">

![image](https://user-images.githubusercontent.com/36246323/124535838-d9b91700-dde4-11eb-9768-1ef5d57f2a07.png)

Logged the current user's country and the displayed schools to the console, and it's the same as in the actual list

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 

npm start and then log into the app as a user with a country that's not "UNITED_STATES"
