### PR TITLE
added timetable field to ReportWithLibraryRequest type

### DIFF
--- a/src/components/report/ReportWithLibrary.tsx
+++ b/src/components/report/ReportWithLibrary.tsx
@@ -31,6 +31,7 @@ const ReportWithLibrary: React.FC<ReportWithLibraryProps> = ({
       numberOfStudentLibrarians: 0,
       parentSupport: '',
       teacherSupport: '',
+      timetable: null,
       ...submittedValues,
       visitReason,
     });

--- a/src/components/report/common/VisitReason.tsx
+++ b/src/components/report/common/VisitReason.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import FormPiece from '../../form-style/FormPiece';
 import { Col, Input, Row, Select } from 'antd';
 import FormContainer from '../../form-style/FormContainer';
+import styled from 'styled-components';
 
 interface VisitReasonProps {
   setVisitReason: (purposeOfVisit: string) => void;
@@ -21,6 +22,10 @@ const reasons = [
   'Emergency / Disaster',
   'Other',
 ];
+
+const PurposeSelect = styled(Select)`
+  width: 300px;
+`;
 
 const VisitReason: React.FC<VisitReasonProps> = ({
   setVisitReason,
@@ -52,7 +57,7 @@ const VisitReason: React.FC<VisitReasonProps> = ({
               defaultValue={otherSelected ? 'Other' : visitReason || undefined}
             >
               {reasons.map((reason, i) => (
-                <Select.Option value={reason} key={i}>
+                <Select.Option className="grant" value={reason} key={i}>
                   {reason}
                 </Select.Option>
               ))}

--- a/src/components/report/common/VisitReason.tsx
+++ b/src/components/report/common/VisitReason.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import FormPiece from '../../form-style/FormPiece';
 import { Col, Input, Row, Select } from 'antd';
 import FormContainer from '../../form-style/FormContainer';
-import styled from 'styled-components';
 
 interface VisitReasonProps {
   setVisitReason: (purposeOfVisit: string) => void;
@@ -51,6 +50,7 @@ const VisitReason: React.FC<VisitReasonProps> = ({
               onChange={onSelected}
               disabled={!editable}
               defaultValue={otherSelected ? 'Other' : visitReason || undefined}
+              style={{width: '300px'}}
             >
               {reasons.map((reason, i) => (
                 <Select.Option value={reason} key={i}>

--- a/src/components/report/common/VisitReason.tsx
+++ b/src/components/report/common/VisitReason.tsx
@@ -23,10 +23,6 @@ const reasons = [
   'Other',
 ];
 
-const PurposeSelect = styled(Select)`
-  width: 300px;
-`;
-
 const VisitReason: React.FC<VisitReasonProps> = ({
   setVisitReason,
   visitReason,
@@ -57,7 +53,7 @@ const VisitReason: React.FC<VisitReasonProps> = ({
               defaultValue={otherSelected ? 'Other' : visitReason || undefined}
             >
               {reasons.map((reason, i) => (
-                <Select.Option className="grant" value={reason} key={i}>
+                <Select.Option value={reason} key={i}>
                   {reason}
                 </Select.Option>
               ))}

--- a/src/containers/library-report/ducks/types.ts
+++ b/src/containers/library-report/ducks/types.ts
@@ -80,7 +80,7 @@ export type Timetable = {
   formThree?: object;
   formFour?: object;
   formFive?: object;
-}
+};
 
 export enum AssignedPersonRole {
   FULL_TIME = 'FULL_TIME',

--- a/src/containers/library-report/ducks/types.ts
+++ b/src/containers/library-report/ducks/types.ts
@@ -65,21 +65,23 @@ export type LibraryReportResponse = {
     } & ReportWithoutLibraryRequest)
 );
 
+type TimetableGrade = { [key: string]: number }
+
 export type Timetable = {
   year: number;
   month: number;
-  kindergarten?: { [key: string]: number };
-  firstGrade?: object;
-  secondGrade?: object;
-  thirdGrade?: object;
-  fourthGrade?: object;
-  fifthGrade?: object;
-  sixthGrade?: object;
-  formOne?: object;
-  formTwo?: object;
-  formThree?: object;
-  formFour?: object;
-  formFive?: object;
+  kindergarten?: TimetableGrade;
+  firstGrade?: TimetableGrade;
+  secondGrade?: TimetableGrade;
+  thirdGrade?: TimetableGrade;
+  fourthGrade?: TimetableGrade;
+  fifthGrade?: TimetableGrade;
+  sixthGrade?: TimetableGrade;
+  formOne?: TimetableGrade;
+  formTwo?: TimetableGrade;
+  formThree?: TimetableGrade;
+  formFour?: TimetableGrade;
+  formFive?: TimetableGrade;
 };
 
 export enum AssignedPersonRole {

--- a/src/containers/library-report/ducks/types.ts
+++ b/src/containers/library-report/ducks/types.ts
@@ -39,6 +39,7 @@ export interface ReportWithLibraryRequest extends LibraryReportShared {
   readonly hasSufficientTraining: null | boolean;
   readonly teacherSupport: null | string;
   readonly parentSupport: null | string;
+  readonly timetable: null | Timetable;
 }
 
 export interface ReportWithoutLibraryRequest extends LibraryReportShared {
@@ -63,6 +64,23 @@ export type LibraryReportResponse = {
       readonly libraryStatus: 'DOES_NOT_EXIST';
     } & ReportWithoutLibraryRequest)
 );
+
+export type Timetable = {
+  year: number;
+  month: number;
+  kindergarten?: Object;
+  firstGrade?: Object;
+  secondGrade?: Object;
+  thirdGrade?: Object;
+  fourthGrade?: Object;
+  fifthGrade?: Object;
+  sixthGrade?: Object;
+  formOne?: Object;
+  formTwo?: Object;
+  formThree?: Object;
+  formFour?: Object;
+  formFive?: Object;
+}
 
 export enum AssignedPersonRole {
   FULL_TIME = 'FULL_TIME',

--- a/src/containers/library-report/ducks/types.ts
+++ b/src/containers/library-report/ducks/types.ts
@@ -68,18 +68,18 @@ export type LibraryReportResponse = {
 export type Timetable = {
   year: number;
   month: number;
-  kindergarten?: Object;
-  firstGrade?: Object;
-  secondGrade?: Object;
-  thirdGrade?: Object;
-  fourthGrade?: Object;
-  fifthGrade?: Object;
-  sixthGrade?: Object;
-  formOne?: Object;
-  formTwo?: Object;
-  formThree?: Object;
-  formFour?: Object;
-  formFive?: Object;
+  kindergarten?: object;
+  firstGrade?: object;
+  secondGrade?: object;
+  thirdGrade?: object;
+  fourthGrade?: object;
+  fifthGrade?: object;
+  sixthGrade?: object;
+  formOne?: object;
+  formTwo?: object;
+  formThree?: object;
+  formFour?: object;
+  formFive?: object;
 }
 
 export enum AssignedPersonRole {

--- a/src/containers/library-report/ducks/types.ts
+++ b/src/containers/library-report/ducks/types.ts
@@ -68,7 +68,7 @@ export type LibraryReportResponse = {
 export type Timetable = {
   year: number;
   month: number;
-  kindergarten?: object;
+  kindergarten?: { [key: string]: number };
   firstGrade?: object;
   secondGrade?: object;
   thirdGrade?: object;

--- a/src/containers/library-report/tests/thunks.test.ts
+++ b/src/containers/library-report/tests/thunks.test.ts
@@ -42,7 +42,7 @@ describe('Report With Library Thunks', () => {
         visitReason: null,
         actionPlans: null,
         successStories: null,
-        timetable: null
+        timetable: null,
       };
 
       mockGetReportWithLibrary.mockResolvedValue(mockReportResponse);

--- a/src/containers/library-report/tests/thunks.test.ts
+++ b/src/containers/library-report/tests/thunks.test.ts
@@ -42,6 +42,7 @@ describe('Report With Library Thunks', () => {
         visitReason: null,
         actionPlans: null,
         successStories: null,
+        timetable: null
       };
 
       mockGetReportWithLibrary.mockResolvedValue(mockReportResponse);


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/866744728/pulses/1492342110)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

added the timetable field to the ReportWithLibraryRequest data type so that the report form works
