### PR TITLE
changed columns to display names instead of titles

### DIFF
--- a/src/containers/library-report/ducks/types.ts
+++ b/src/containers/library-report/ducks/types.ts
@@ -56,6 +56,8 @@ export type LibraryReportResponse = {
   readonly updatedAt: string;
   readonly schoolId: number;
   readonly userId: number;
+  readonly userName: string;
+  readonly schoolName: string;
 } & (
   | ({
       readonly libraryStatus: 'EXISTS';

--- a/src/containers/library-report/tests/thunks.test.ts
+++ b/src/containers/library-report/tests/thunks.test.ts
@@ -43,6 +43,8 @@ describe('Report With Library Thunks', () => {
         actionPlans: null,
         successStories: null,
         timetable: null,
+        userName: '',
+        schoolName: '',
       };
 
       mockGetReportWithLibrary.mockResolvedValue(mockReportResponse);

--- a/src/containers/pastSubmissionsReports/PastSubmissionReports.tsx
+++ b/src/containers/pastSubmissionsReports/PastSubmissionReports.tsx
@@ -60,14 +60,14 @@ const PastSubmissionsReports: React.FC = () => {
       },
     },
     {
-      title: 'School ID',
-      dataIndex: 'schoolId',
+      title: 'School Name',
+      dataIndex: 'schoolName',
     },
     {
-      title: 'User ID',
-      dataIndex: 'userId',
+      title: 'User Name',
+      dataIndex: 'userName',
       sorter: {
-        compare: (a, b) => (a.userId > b.userId ? 1 : -1),
+        compare: (a, b) => a.userName.localeCompare(b.userName),
         multiple: 1,
       },
     },


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/866744728/pulses/1500401148)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

Changes user ID and school ID to their corresponding names

Can't verify if this works because the tab to view submitted reports is giving me an error
