### PR TITLE
Checkout Timetable

### DIFF
--- a/src/components/report/ReportWithLibrary.tsx
+++ b/src/components/report/ReportWithLibrary.tsx
@@ -26,15 +26,26 @@ const ReportWithLibrary: React.FC<ReportWithLibraryProps> = ({
   children,
 }) => {
   const [visitReason, setVisitReason] = useState(values?.visitReason || null);
-  const [timeTable, setTimeTable] = useState<Timetable | null>(null);
-  const [showTimeTable, setShowTimeTable] = useState<boolean>(false);
+  const [checkInTimeTable, setCheckInTimeTable] = useState<Timetable | null>(
+    null,
+  );
+  const [showCheckInTimeTable, setShowCheckInTimeTable] = useState<boolean>(
+    false,
+  );
+  const [checkOutTimeTable, setCheckOutTimeTable] = useState<Timetable | null>(
+    null,
+  );
+  const [showCheckOutTimeTable, setShowCheckOutTimeTable] = useState<boolean>(
+    false,
+  );
 
   const handleSubmit = (submittedValues: ReportWithLibraryRequest) => {
     onSubmit({
       numberOfStudentLibrarians: 0,
       parentSupport: '',
       teacherSupport: '',
-      timetable: showTimeTable ? timeTable : null,
+      checkInTimetable: showCheckInTimeTable ? checkInTimeTable : null,
+      checkOutTimetable: showCheckOutTimeTable ? checkOutTimeTable : null,
       ...submittedValues,
       visitReason,
     });
@@ -60,10 +71,14 @@ const ReportWithLibrary: React.FC<ReportWithLibraryProps> = ({
         <LibraryInfo editable={editable} />
         <MonitoringInfo
           editable={editable}
-          showTimeTable={showTimeTable}
-          setShowTimeTable={setShowTimeTable}
-          timeTable={timeTable}
-          setTimeTable={setTimeTable}
+          showCheckInTimeTable={showCheckInTimeTable}
+          setShowCheckInTimeTable={setShowCheckInTimeTable}
+          checkInTimeTable={checkInTimeTable}
+          setCheckInTimeTable={setCheckInTimeTable}
+          showCheckOutTimeTable={showCheckOutTimeTable}
+          setShowCheckOutTimeTable={setShowCheckOutTimeTable}
+          checkOutTimeTable={checkOutTimeTable}
+          setCheckOutTimeTable={setCheckOutTimeTable}
         />
         <TrainingMentorshipInfo editable={editable} report={values} />
         <ChangesActionPlan editable={editable} />

--- a/src/components/report/withLibrary/MonitoringInfo.tsx
+++ b/src/components/report/withLibrary/MonitoringInfo.tsx
@@ -7,28 +7,51 @@ import TimeTable from './TimeTable';
 
 interface MonitoringInfoProps {
   editable?: boolean;
-  setTimeTable: (tt: Timetable) => void;
-  timeTable: Timetable | null;
-  showTimeTable: boolean;
-  setShowTimeTable: (value: boolean) => void;
+
+  setCheckInTimeTable: (tt: Timetable) => void;
+  checkInTimeTable: Timetable | null;
+  showCheckInTimeTable: boolean;
+  setShowCheckInTimeTable: (value: boolean) => void;
+
+  setCheckOutTimeTable: (tt: Timetable) => void;
+  checkOutTimeTable: Timetable | null;
+  showCheckOutTimeTable: boolean;
+  setShowCheckOutTimeTable: (value: boolean) => void;
 }
 
 const MonitoringInfo: React.FC<MonitoringInfoProps> = ({
   editable,
-  setTimeTable,
-  timeTable,
-  setShowTimeTable,
-  showTimeTable,
+  setCheckInTimeTable,
+  checkInTimeTable,
+  setShowCheckInTimeTable,
+  showCheckInTimeTable,
+  setCheckOutTimeTable,
+  checkOutTimeTable,
+  setShowCheckOutTimeTable,
+  showCheckOutTimeTable,
 }) => {
   return (
     <FormContainer title="Monitoring Information">
+      {showCheckInTimeTable && (
+        <Row gutter={[0, 24]}>
+          <Col span={24}>
+            <TimeTable
+              name="Classroom Check-In Table"
+              timeTable={checkInTimeTable}
+              setTimeTable={setCheckInTimeTable}
+            />
+          </Col>
+        </Row>
+      )}
       <Row gutter={[24, 0]}>
         <Col span={12}>
           <FormPieceBoolean
             name={'hasCheckInTimetables'}
             note={'Does this library keep classroom check-in timetables?'}
             disabled={!editable}
-            onChange={(event: any) => setShowTimeTable(event.target.value)}
+            onChange={(event: any) =>
+              setShowCheckInTimeTable(event.target.value)
+            }
           />
         </Col>
         <Col span={12}>
@@ -36,13 +59,20 @@ const MonitoringInfo: React.FC<MonitoringInfoProps> = ({
             name={'hasBookCheckoutSystem'}
             note={'Does the library have a system for book checkouts?'}
             disabled={!editable}
+            onChange={(event: any) =>
+              setShowCheckOutTimeTable(event.target.value)
+            }
           />
         </Col>
       </Row>
-      {showTimeTable && (
+      {showCheckOutTimeTable && (
         <Row gutter={[0, 24]}>
           <Col span={24}>
-            <TimeTable timeTable={timeTable} setTimeTable={setTimeTable} />
+            <TimeTable
+              name="Book Check-Out Table"
+              timeTable={checkOutTimeTable}
+              setTimeTable={setCheckOutTimeTable}
+            />
           </Col>
         </Row>
       )}

--- a/src/components/report/withLibrary/TimeTable.tsx
+++ b/src/components/report/withLibrary/TimeTable.tsx
@@ -1,4 +1,4 @@
-import { DatePicker, InputNumber, Table } from 'antd';
+import { Col, DatePicker, InputNumber, Row, Table, Typography } from 'antd';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import {
@@ -11,7 +11,24 @@ import moment, { Moment } from 'moment';
 interface TimeTableProps {
   setTimeTable: (tt: Timetable) => void;
   timeTable: Timetable | null;
+  name: string;
 }
+
+const { Title } = Typography;
+
+const Container = styled.div`
+  margin-bottom: 24px;
+`;
+
+const TitleRow = styled(Row)`
+  background: white;
+  margin-bottom: 24px;
+  padding-top: 24px;
+`;
+
+const TableTitle = styled(Title)`
+  text-align: center;
+`;
 
 const SmallInputNumber = styled(InputNumber)`
   width: 4rem;
@@ -22,7 +39,11 @@ interface TimeTableDataType {
   grade: string;
 }
 
-const TimeTable: React.FC<TimeTableProps> = ({ setTimeTable, timeTable }) => {
+const TimeTable: React.FC<TimeTableProps> = ({
+  setTimeTable,
+  timeTable,
+  name,
+}) => {
   const [year, setYear] = useState<number>(new Date().getFullYear());
   const [month, setMonth] = useState<number>(new Date().getMonth() + 1);
   const [days, setDays] = useState<number>(daysInMonth(year, month));
@@ -118,22 +139,31 @@ const TimeTable: React.FC<TimeTableProps> = ({ setTimeTable, timeTable }) => {
   }));
 
   return (
-    <>
-      <DatePicker
-        defaultValue={moment(new Date())}
-        onChange={onChangeDate}
-        picker="month"
-        size="large"
-      />
-      <Table
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        columns={columns}
-        dataSource={data}
-        scroll={{ x: 1300 }}
-        pagination={false}
-      />
-    </>
+    <Container>
+      <TitleRow gutter={[0, 24]} justify="center">
+        <Col span={8}>
+          <DatePicker
+            defaultValue={moment(new Date())}
+            onChange={onChangeDate}
+            picker="month"
+            size="large"
+          />
+        </Col>
+        <Col span={16}>
+          <TableTitle level={1}>{name}</TableTitle>
+        </Col>
+      </TitleRow>
+      <Row gutter={[0, 24]}>
+        <Table
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          columns={columns}
+          dataSource={data}
+          scroll={{ x: 1300 }}
+          pagination={false}
+        />
+      </Row>
+    </Container>
   );
 };
 

--- a/src/containers/library-report/ducks/types.ts
+++ b/src/containers/library-report/ducks/types.ts
@@ -39,7 +39,8 @@ export interface ReportWithLibraryRequest extends LibraryReportShared {
   readonly hasSufficientTraining: null | boolean;
   readonly teacherSupport: null | string;
   readonly parentSupport: null | string;
-  readonly timetable: null | Timetable;
+  readonly checkInTimetable: null | Timetable;
+  readonly checkOutTimetable: null | Timetable;
 }
 
 export interface ReportWithoutLibraryRequest extends LibraryReportShared {

--- a/src/containers/library-report/tests/thunks.test.ts
+++ b/src/containers/library-report/tests/thunks.test.ts
@@ -42,7 +42,8 @@ describe('Report With Library Thunks', () => {
         visitReason: null,
         actionPlans: null,
         successStories: null,
-        timetable: null,
+        checkInTimetable: null,
+        checkOutTimetable: null,
       };
 
       mockGetReportWithLibrary.mockResolvedValue(mockReportResponse);


### PR DESCRIPTION
## This PR

Added another timetable for the book check-out question. This PR is stuck until the backend updates the DTO for a report with library to include a `checkInTimetable` and `checkOutTimetable`.

## Screenshots

<img width="284" alt="Screen Shot 2021-08-03 at 3 14 57 PM" src="https://user-images.githubusercontent.com/55663613/128073476-f6dcb1b7-8500-4004-b9bd-c5694467120a.png">

