### PR TITLE
Gt.school and book infoin report

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4166,25 +4166,20 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.16.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
-      "integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+      "version": "4.14.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.6.tgz",
+      "integrity": "sha512-zeFYcUo85ENhc/zxHbiIp0LGzzTrE2Pv2JhxvS7kpUb9Q9D38kUX6Bie7pGutJ/5iF5rOxE7CepAuWD56xJ33A==",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001248",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.793",
+        "caniuse-lite": "^1.0.30001154",
+        "electron-to-chromium": "^1.3.585",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.73"
+        "node-releases": "^1.1.65"
       },
       "bin": {
         "browserslist": "cli.js"
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
       }
     },
     "node_modules/bser": {
@@ -4353,9 +4348,9 @@
       }
     },
     "node_modules/cacheable-request/node_modules/normalize-url": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -4444,13 +4439,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001251",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001214",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001214.tgz",
+      "integrity": "sha512-O2/SCpuaU3eASWVaesQirZv1MSjUNOvmugaD8zNSJqw6Vv5SGwoOpA9LJs3pNPfM745nxqPvfZY3MQKY4AKHYg=="
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -5121,6 +5112,24 @@
       "dependencies": {
         "browserslist": "^4.16.4",
         "semver": "7.0.0"
+      }
+    },
+    "node_modules/core-js-compat/node_modules/browserslist": {
+      "version": "4.16.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.5.tgz",
+      "integrity": "sha512-C2HAjrM1AI/djrpAUU/tr4pml1DqLIzJKSLDBXBrNErl9ZCCTXdhwxdJjYc16953+mBWf7Lw+uUJgpgb8cN71A==",
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001214",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.719",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.71"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/core-js-compat/node_modules/semver": {
@@ -5961,9 +5970,9 @@
       "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
     },
     "node_modules/dns-packet": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
-      "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
+      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
       "dependencies": {
         "ip": "^1.1.0",
         "safe-buffer": "^5.0.1"
@@ -6156,9 +6165,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.806",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.806.tgz",
-      "integrity": "sha512-AH/otJLAAecgyrYp0XK1DPiGVWcOgwPeJBOLeuFQ5l//vhQhwC9u6d+GijClqJAmsHG4XDue81ndSQPohUu0xA=="
+      "version": "1.3.720",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.720.tgz",
+      "integrity": "sha512-B6zLTxxaOFP4WZm6DrvgRk8kLFYWNhQ5TrHMC0l5WtkMXhU5UbnvWoTfeEwqOruUSlNMhVLfYak7REX6oC5Yfw=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -7966,9 +7975,9 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -9598,9 +9607,9 @@
       }
     },
     "node_modules/jest-environment-jsdom-fourteen/node_modules/ws": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
-      "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
       "dependencies": {
         "async-limiter": "~1.0.0"
       }
@@ -11456,9 +11465,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "1.1.74",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.74.tgz",
-      "integrity": "sha512-caJBVempXZPepZoZAPCWRTNxYQ+xtG/KAi4ozTA5A+nJ7IU+kLQCbqaUjb5Rwy14M9upBWiQ4NutcmW04LJSRw=="
+      "version": "1.1.71",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
     },
     "node_modules/nodemon": {
       "version": "2.0.7",
@@ -12212,9 +12221,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
@@ -12374,9 +12383,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "7.0.36",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-      "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
+      "version": "7.0.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
+      "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
       "dependencies": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -12384,10 +12393,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-attribute-case-insensitive": {
@@ -16452,9 +16457,9 @@
       }
     },
     "node_modules/ssri": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.1.tgz",
-      "integrity": "sha512-w+daCzXN89PseTL99MkA+fxJEcU3wfaE/ah0i0lnOlpG1CYLJ2ZjzEry68YBKfLs4JfoTShrTEsJkAZuNZ/stw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
+      "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
       "dependencies": {
         "figgy-pudding": "^3.5.1",
         "minipass": "^3.1.1"
@@ -17984,9 +17989,9 @@
       }
     },
     "node_modules/url-parse": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
-      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -18821,9 +18826,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
-      "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
       "dependencies": {
         "async-limiter": "~1.0.0"
       }
@@ -19353,9 +19358,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
-      "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
       "dependencies": {
         "async-limiter": "~1.0.0"
       }
@@ -23178,15 +23183,14 @@
       }
     },
     "browserslist": {
-      "version": "4.16.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
-      "integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+      "version": "4.14.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.6.tgz",
+      "integrity": "sha512-zeFYcUo85ENhc/zxHbiIp0LGzzTrE2Pv2JhxvS7kpUb9Q9D38kUX6Bie7pGutJ/5iF5rOxE7CepAuWD56xJ33A==",
       "requires": {
-        "caniuse-lite": "^1.0.30001248",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.793",
+        "caniuse-lite": "^1.0.30001154",
+        "electron-to-chromium": "^1.3.585",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.73"
+        "node-releases": "^1.1.65"
       }
     },
     "bser": {
@@ -23333,9 +23337,9 @@
           "dev": true
         },
         "normalize-url": {
-          "version": "4.5.1",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-          "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+          "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
           "dev": true
         }
       }
@@ -23413,9 +23417,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001251",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A=="
+      "version": "1.0.30001214",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001214.tgz",
+      "integrity": "sha512-O2/SCpuaU3eASWVaesQirZv1MSjUNOvmugaD8zNSJqw6Vv5SGwoOpA9LJs3pNPfM745nxqPvfZY3MQKY4AKHYg=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -23983,6 +23987,18 @@
         "semver": "7.0.0"
       },
       "dependencies": {
+        "browserslist": {
+          "version": "4.16.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.5.tgz",
+          "integrity": "sha512-C2HAjrM1AI/djrpAUU/tr4pml1DqLIzJKSLDBXBrNErl9ZCCTXdhwxdJjYc16953+mBWf7Lw+uUJgpgb8cN71A==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001214",
+            "colorette": "^1.2.2",
+            "electron-to-chromium": "^1.3.719",
+            "escalade": "^3.1.1",
+            "node-releases": "^1.1.71"
+          }
+        },
         "semver": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
@@ -24674,9 +24690,9 @@
       "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
     },
     "dns-packet": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
-      "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
+      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
       "requires": {
         "ip": "^1.1.0",
         "safe-buffer": "^5.0.1"
@@ -24862,9 +24878,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.806",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.806.tgz",
-      "integrity": "sha512-AH/otJLAAecgyrYp0XK1DPiGVWcOgwPeJBOLeuFQ5l//vhQhwC9u6d+GijClqJAmsHG4XDue81ndSQPohUu0xA=="
+      "version": "1.3.720",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.720.tgz",
+      "integrity": "sha512-B6zLTxxaOFP4WZm6DrvgRk8kLFYWNhQ5TrHMC0l5WtkMXhU5UbnvWoTfeEwqOruUSlNMhVLfYak7REX6oC5Yfw=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -26362,9 +26378,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -27669,9 +27685,9 @@
           }
         },
         "ws": {
-          "version": "6.2.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
-          "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
           "requires": {
             "async-limiter": "~1.0.0"
           }
@@ -29223,9 +29239,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.74",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.74.tgz",
-      "integrity": "sha512-caJBVempXZPepZoZAPCWRTNxYQ+xtG/KAi4ozTA5A+nJ7IU+kLQCbqaUjb5Rwy14M9upBWiQ4NutcmW04LJSRw=="
+      "version": "1.1.71",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
     },
     "nodemon": {
       "version": "2.0.7",
@@ -29834,9 +29850,9 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -29961,9 +29977,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "7.0.36",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-      "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
+      "version": "7.0.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
+      "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -33433,9 +33449,9 @@
       }
     },
     "ssri": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.1.tgz",
-      "integrity": "sha512-w+daCzXN89PseTL99MkA+fxJEcU3wfaE/ah0i0lnOlpG1CYLJ2ZjzEry68YBKfLs4JfoTShrTEsJkAZuNZ/stw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
+      "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
       "requires": {
         "figgy-pudding": "^3.5.1",
         "minipass": "^3.1.1"
@@ -34695,9 +34711,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
-      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -35491,9 +35507,9 @@
           }
         },
         "ws": {
-          "version": "6.2.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
-          "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
           "requires": {
             "async-limiter": "~1.0.0"
           }
@@ -35878,9 +35894,9 @@
       }
     },
     "ws": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
-      "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
       "requires": {
         "async-limiter": "~1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4166,20 +4166,25 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.14.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.6.tgz",
-      "integrity": "sha512-zeFYcUo85ENhc/zxHbiIp0LGzzTrE2Pv2JhxvS7kpUb9Q9D38kUX6Bie7pGutJ/5iF5rOxE7CepAuWD56xJ33A==",
+      "version": "4.16.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
+      "integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001154",
-        "electron-to-chromium": "^1.3.585",
+        "caniuse-lite": "^1.0.30001248",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.793",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.65"
+        "node-releases": "^1.1.73"
       },
       "bin": {
         "browserslist": "cli.js"
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
       }
     },
     "node_modules/bser": {
@@ -4348,9 +4353,9 @@
       }
     },
     "node_modules/cacheable-request/node_modules/normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -4439,9 +4444,13 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001214",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001214.tgz",
-      "integrity": "sha512-O2/SCpuaU3eASWVaesQirZv1MSjUNOvmugaD8zNSJqw6Vv5SGwoOpA9LJs3pNPfM745nxqPvfZY3MQKY4AKHYg=="
+      "version": "1.0.30001251",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
+      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -5112,24 +5121,6 @@
       "dependencies": {
         "browserslist": "^4.16.4",
         "semver": "7.0.0"
-      }
-    },
-    "node_modules/core-js-compat/node_modules/browserslist": {
-      "version": "4.16.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.5.tgz",
-      "integrity": "sha512-C2HAjrM1AI/djrpAUU/tr4pml1DqLIzJKSLDBXBrNErl9ZCCTXdhwxdJjYc16953+mBWf7Lw+uUJgpgb8cN71A==",
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001214",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.719",
-        "escalade": "^3.1.1",
-        "node-releases": "^1.1.71"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/core-js-compat/node_modules/semver": {
@@ -5970,9 +5961,9 @@
       "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
     },
     "node_modules/dns-packet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
+      "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
       "dependencies": {
         "ip": "^1.1.0",
         "safe-buffer": "^5.0.1"
@@ -6165,9 +6156,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.720",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.720.tgz",
-      "integrity": "sha512-B6zLTxxaOFP4WZm6DrvgRk8kLFYWNhQ5TrHMC0l5WtkMXhU5UbnvWoTfeEwqOruUSlNMhVLfYak7REX6oC5Yfw=="
+      "version": "1.3.806",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.806.tgz",
+      "integrity": "sha512-AH/otJLAAecgyrYp0XK1DPiGVWcOgwPeJBOLeuFQ5l//vhQhwC9u6d+GijClqJAmsHG4XDue81ndSQPohUu0xA=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -7975,9 +7966,9 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -9607,9 +9598,9 @@
       }
     },
     "node_modules/jest-environment-jsdom-fourteen/node_modules/ws": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+      "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
       "dependencies": {
         "async-limiter": "~1.0.0"
       }
@@ -11465,9 +11456,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "1.1.71",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
+      "version": "1.1.74",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.74.tgz",
+      "integrity": "sha512-caJBVempXZPepZoZAPCWRTNxYQ+xtG/KAi4ozTA5A+nJ7IU+kLQCbqaUjb5Rwy14M9upBWiQ4NutcmW04LJSRw=="
     },
     "node_modules/nodemon": {
       "version": "2.0.7",
@@ -12221,9 +12212,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
@@ -12383,9 +12374,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "7.0.35",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-      "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+      "version": "7.0.36",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+      "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
       "dependencies": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -12393,6 +12384,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-attribute-case-insensitive": {
@@ -16457,9 +16452,9 @@
       }
     },
     "node_modules/ssri": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
-      "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.1.tgz",
+      "integrity": "sha512-w+daCzXN89PseTL99MkA+fxJEcU3wfaE/ah0i0lnOlpG1CYLJ2ZjzEry68YBKfLs4JfoTShrTEsJkAZuNZ/stw==",
       "dependencies": {
         "figgy-pudding": "^3.5.1",
         "minipass": "^3.1.1"
@@ -17989,9 +17984,9 @@
       }
     },
     "node_modules/url-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -18826,9 +18821,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+      "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
       "dependencies": {
         "async-limiter": "~1.0.0"
       }
@@ -19358,9 +19353,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
+      "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
       "dependencies": {
         "async-limiter": "~1.0.0"
       }
@@ -23183,14 +23178,15 @@
       }
     },
     "browserslist": {
-      "version": "4.14.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.6.tgz",
-      "integrity": "sha512-zeFYcUo85ENhc/zxHbiIp0LGzzTrE2Pv2JhxvS7kpUb9Q9D38kUX6Bie7pGutJ/5iF5rOxE7CepAuWD56xJ33A==",
+      "version": "4.16.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
+      "integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
       "requires": {
-        "caniuse-lite": "^1.0.30001154",
-        "electron-to-chromium": "^1.3.585",
+        "caniuse-lite": "^1.0.30001248",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.793",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.65"
+        "node-releases": "^1.1.73"
       }
     },
     "bser": {
@@ -23337,9 +23333,9 @@
           "dev": true
         },
         "normalize-url": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-          "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+          "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
           "dev": true
         }
       }
@@ -23417,9 +23413,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001214",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001214.tgz",
-      "integrity": "sha512-O2/SCpuaU3eASWVaesQirZv1MSjUNOvmugaD8zNSJqw6Vv5SGwoOpA9LJs3pNPfM745nxqPvfZY3MQKY4AKHYg=="
+      "version": "1.0.30001251",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
+      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -23987,18 +23983,6 @@
         "semver": "7.0.0"
       },
       "dependencies": {
-        "browserslist": {
-          "version": "4.16.5",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.5.tgz",
-          "integrity": "sha512-C2HAjrM1AI/djrpAUU/tr4pml1DqLIzJKSLDBXBrNErl9ZCCTXdhwxdJjYc16953+mBWf7Lw+uUJgpgb8cN71A==",
-          "requires": {
-            "caniuse-lite": "^1.0.30001214",
-            "colorette": "^1.2.2",
-            "electron-to-chromium": "^1.3.719",
-            "escalade": "^3.1.1",
-            "node-releases": "^1.1.71"
-          }
-        },
         "semver": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
@@ -24690,9 +24674,9 @@
       "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
     },
     "dns-packet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
+      "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
       "requires": {
         "ip": "^1.1.0",
         "safe-buffer": "^5.0.1"
@@ -24878,9 +24862,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.720",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.720.tgz",
-      "integrity": "sha512-B6zLTxxaOFP4WZm6DrvgRk8kLFYWNhQ5TrHMC0l5WtkMXhU5UbnvWoTfeEwqOruUSlNMhVLfYak7REX6oC5Yfw=="
+      "version": "1.3.806",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.806.tgz",
+      "integrity": "sha512-AH/otJLAAecgyrYp0XK1DPiGVWcOgwPeJBOLeuFQ5l//vhQhwC9u6d+GijClqJAmsHG4XDue81ndSQPohUu0xA=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -26378,9 +26362,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -27685,9 +27669,9 @@
           }
         },
         "ws": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+          "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
           "requires": {
             "async-limiter": "~1.0.0"
           }
@@ -29239,9 +29223,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.71",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
+      "version": "1.1.74",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.74.tgz",
+      "integrity": "sha512-caJBVempXZPepZoZAPCWRTNxYQ+xtG/KAi4ozTA5A+nJ7IU+kLQCbqaUjb5Rwy14M9upBWiQ4NutcmW04LJSRw=="
     },
     "nodemon": {
       "version": "2.0.7",
@@ -29850,9 +29834,9 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -29977,9 +29961,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "7.0.35",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-      "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+      "version": "7.0.36",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+      "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -33449,9 +33433,9 @@
       }
     },
     "ssri": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
-      "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.1.tgz",
+      "integrity": "sha512-w+daCzXN89PseTL99MkA+fxJEcU3wfaE/ah0i0lnOlpG1CYLJ2ZjzEry68YBKfLs4JfoTShrTEsJkAZuNZ/stw==",
       "requires": {
         "figgy-pudding": "^3.5.1",
         "minipass": "^3.1.1"
@@ -34711,9 +34695,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -35507,9 +35491,9 @@
           }
         },
         "ws": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+          "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
           "requires": {
             "async-limiter": "~1.0.0"
           }
@@ -35894,9 +35878,9 @@
       }
     },
     "ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
+      "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
       "requires": {
         "async-limiter": "~1.0.0"
       }

--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -278,14 +278,16 @@ const deleteSchoolContact = (
   ).then((res) => res.data);
 };
 
-const getLatestReportWithLibrary = (schoolId: number): Promise<LibraryReportResponse> => {
+const getLatestReportWithLibrary = (
+  schoolId: number,
+): Promise<LibraryReportResponse> => {
   return AppAxiosInstance.get(
     `${ProtectedApiClientRoutes.SINGLE_LIBRARY_REPORT.replace(
       ':school_id',
       schoolId.toString(),
-    )}`
-  ).then((res) => res.data)
-}
+    )}`,
+  ).then((res) => res.data);
+};
 
 const getLatestReport = (schoolId: number): Promise<LibraryReportResponse> => {
   return AppAxiosInstance.get(
@@ -449,7 +451,7 @@ const Client: ProtectedApiClient = Object.freeze({
   editReportWithoutLibrary,
   getPastSubmissionSchools,
   getPastSubmissionReports,
-  getLatestReportWithLibrary
+  getLatestReportWithLibrary,
 });
 
 export default Client;

--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -78,6 +78,11 @@ export interface ProtectedApiClient {
   readonly getLatestReport: (
     schoolId: number,
   ) => Promise<LibraryReportResponse>;
+
+  readonly getLatestReportWithLibrary: (
+    schoolId: number,
+  ) => Promise<LibraryReportResponse>;
+
   readonly createBookLog: (
     schoolId: number,
     report: BookLogPostRequest,
@@ -136,6 +141,7 @@ export enum ProtectedApiClientRoutes {
   REPORT_WITHOUT_LIBRARY = '/api/v1/protected/schools/:school_id/reports/without-library',
   REPORT_WITH_LIBRARY = '/api/v1/protected/schools/:school_id/reports/with-library',
   LIBRARY_REPORTS = '/api/v1/protected/schools/:school_id/reports',
+  SINGLE_LIBRARY_REPORT = '/api/v1/protected/schools/:school_id/report',
   BOOK_REPORTS = '/api/v1/protected/schools/:school_id/books',
   PAST_SUBMISSIONS_SCHOOLS = '/api/v1/protected/schools/reports/users',
 }
@@ -271,6 +277,15 @@ const deleteSchoolContact = (
     )}/${contactId.toString()}`,
   ).then((res) => res.data);
 };
+
+const getLatestReportWithLibrary = (schoolId: number): Promise<LibraryReportResponse> => {
+  return AppAxiosInstance.get(
+    `${ProtectedApiClientRoutes.SINGLE_LIBRARY_REPORT.replace(
+      ':school_id',
+      schoolId.toString(),
+    )}`
+  ).then((res) => res.data)
+}
 
 const getLatestReport = (schoolId: number): Promise<LibraryReportResponse> => {
   return AppAxiosInstance.get(
@@ -434,6 +449,7 @@ const Client: ProtectedApiClient = Object.freeze({
   editReportWithoutLibrary,
   getPastSubmissionSchools,
   getPastSubmissionReports,
+  getLatestReportWithLibrary
 });
 
 export default Client;

--- a/src/components/report/ReportWithLibrary.tsx
+++ b/src/components/report/ReportWithLibrary.tsx
@@ -62,14 +62,13 @@ const ReportWithLibrary: React.FC<ReportWithLibraryProps> = ({
   return (
     <>
       {(asyncRequestIsNotStarted(latestReport) || asyncRequestIsLoading(latestReport)) && <p>Loading school data...</p>}
-      {asyncRequestIsFailed(latestReport) && <p>Failed to load report</p>}
-      {asyncRequestIsComplete(latestReport) && (
+      { asyncRequestIsFailed(latestReport) && !isNew && <p>Failed to load report</p>}
+      {(asyncRequestIsComplete(latestReport) || asyncRequestIsFailed(latestReport)) && (
         <FormContentContainer>
           <Form
             initialValues={
-              isNew
-                ? (initializeNewReportForm(
-                    latestReport.result,
+              isNew ? (initializeNewReportForm(
+                    asyncRequestIsComplete(latestReport) ? latestReport.result : values,
                     bookLogInfo,
                     true,
                   ) as ReportWithLibraryRequest)

--- a/src/components/report/ReportWithLibrary.tsx
+++ b/src/components/report/ReportWithLibrary.tsx
@@ -31,18 +31,14 @@ const ReportWithLibrary: React.FC<ReportWithLibraryProps> = ({
   onSubmit,
   bookLogInfo,
   children,
-  isNew
+  isNew,
 }) => {
   const [visitReason, setVisitReason] = useState(values?.visitReason || null);
   const [timeTable, setTimeTable] = useState<Timetable | null>(null);
   const [showTimeTable, setShowTimeTable] = useState<boolean>(false);
 
-  const latestReport: AsyncRequest<
-    LibraryReportResponse,
-    any
-  > = useSelector(
-    (state: C4CState) =>
-      state.libraryReportState.latestReport,
+  const latestReport: AsyncRequest<LibraryReportResponse, any> = useSelector(
+    (state: C4CState) => state.libraryReportState.latestReport,
   );
 
   const handleSubmit = (submittedValues: ReportWithLibraryRequest) => {
@@ -55,79 +51,91 @@ const ReportWithLibrary: React.FC<ReportWithLibraryProps> = ({
       visitReason,
     });
   };
-   
-   switch (latestReport.kind) {
-      case AsyncRequestKinds.NotStarted:
-      case AsyncRequestKinds.Loading:
-        return <p>Loading school data</p>;
-      
-      case AsyncRequestKinds.Failed:
-      case AsyncRequestKinds.Completed:
-        const reportRequest = isNew && latestReport.kind === AsyncRequestKinds.Completed 
-          ? nullifyWithLibraryReport(latestReport.result, bookLogInfo) : values;
-        return (
-          <FormContentContainer>
-            <Form
-              initialValues={reportRequest}
-              onFinish={handleSubmit}
-              onFinishFailed={() =>
-                message.error(
-                  'Error submitting form, please double check your responses and try again.',
-                )
-              }
-            >
-              <VisitReason
-                setVisitReason={setVisitReason}
-                visitReason={visitReason}
-                editable={editable}
-              />
-              <StudentBookInformation editable={editable} />
-              <LibraryInfo editable={editable} />
-              <MonitoringInfo
-                editable={editable}
-                showTimeTable={showTimeTable}
-                setShowTimeTable={setShowTimeTable}
-                timeTable={timeTable}
-                setTimeTable={setTimeTable}
-              />
-              <TrainingMentorshipInfo editable={editable} report={values} />
-              <ChangesActionPlan editable={editable} />
-              {children}
-            </Form>
-          </FormContentContainer>
-        );
-   }
+
+  switch (latestReport.kind) {
+    case AsyncRequestKinds.NotStarted:
+    case AsyncRequestKinds.Loading:
+      return <p>Loading school data</p>;
+
+    case AsyncRequestKinds.Failed:
+    case AsyncRequestKinds.Completed:
+      const reportRequest =
+        isNew && latestReport.kind === AsyncRequestKinds.Completed
+          ? nullifyWithLibraryReport(latestReport.result, bookLogInfo)
+          : values;
+      return (
+        <FormContentContainer>
+          <Form
+            initialValues={reportRequest}
+            onFinish={handleSubmit}
+            onFinishFailed={() =>
+              message.error(
+                'Error submitting form, please double check your responses and try again.',
+              )
+            }
+          >
+            <VisitReason
+              setVisitReason={setVisitReason}
+              visitReason={visitReason}
+              editable={editable}
+            />
+            <StudentBookInformation editable={editable} />
+            <LibraryInfo editable={editable} />
+            <MonitoringInfo
+              editable={editable}
+              showTimeTable={showTimeTable}
+              setShowTimeTable={setShowTimeTable}
+              timeTable={timeTable}
+              setTimeTable={setTimeTable}
+            />
+            <TrainingMentorshipInfo editable={editable} report={values} />
+            <ChangesActionPlan editable={editable} />
+            {children}
+          </Form>
+        </FormContentContainer>
+      );
+  }
 };
 
-const nullifyWithLibraryReport = (report: LibraryReportResponse | undefined, bookLogs: BookLogResponse[]): ReportWithLibraryRequest  | undefined => {
+const nullifyWithLibraryReport = (
+  report: LibraryReportResponse | undefined,
+  bookLogs: BookLogResponse[],
+): ReportWithLibraryRequest | undefined => {
   if (report === undefined) {
     return undefined;
   }
-  bookLogs.sort((a, b) => parseInt(b.date.toString().split(' ')[5]) - parseInt(a.date.toString().split(' ')[5]));
+  bookLogs.sort(
+    (a, b) =>
+      parseInt(b.date.toString().split(' ')[5], 10) -
+      parseInt(a.date.toString().split(' ')[5], 10),
+  );
   const reportRequest: ReportWithLibraryRequest = {
     numberOfChildren: report.numberOfChildren,
     gradesAttended: report.gradesAttended,
-    numberOfBooks: bookLogs.reduce((a, b) => a + b.count, 0), 
-    mostRecentShipmentYear: parseInt(bookLogs[0].date.toString().split(' ')[5]), 
-    visitReason: null, 
-    actionPlans: null, 
-    successStories: null, 
-    isSharedSpace: null, 
-    hasInvitingSpace: null, 
-    assignedPersonRole: null, 
-    assignedPersonTitle: null, 
-    apprenticeshipProgram: null, 
-    trainsAndMentorsApprentices: null, 
-    hasCheckInTimetables: null, 
-    hasBookCheckoutSystem: null, 
-    numberOfStudentLibrarians: null, 
-    reasonNoStudentLibrarians: null, 
-    hasSufficientTraining: null, 
-    teacherSupport: null, 
-    parentSupport: null, 
-    timetable: null
-  }
+    numberOfBooks: bookLogs.reduce((a, b) => a + b.count, 0),
+    mostRecentShipmentYear: parseInt(
+      bookLogs[0].date.toString().split(' ')[5],
+      10,
+    ),
+    visitReason: null,
+    actionPlans: null,
+    successStories: null,
+    isSharedSpace: null,
+    hasInvitingSpace: null,
+    assignedPersonRole: null,
+    assignedPersonTitle: null,
+    apprenticeshipProgram: null,
+    trainsAndMentorsApprentices: null,
+    hasCheckInTimetables: null,
+    hasBookCheckoutSystem: null,
+    numberOfStudentLibrarians: null,
+    reasonNoStudentLibrarians: null,
+    hasSufficientTraining: null,
+    teacherSupport: null,
+    parentSupport: null,
+    timetable: null,
+  };
   return reportRequest;
-}
+};
 
 export default ReportWithLibrary;

--- a/src/components/report/ReportWithLibrary.tsx
+++ b/src/components/report/ReportWithLibrary.tsx
@@ -61,7 +61,8 @@ const ReportWithLibrary: React.FC<ReportWithLibraryProps> = ({
       const reportRequest =
         isNew && latestReport.kind === AsyncRequestKinds.Completed
           ? nullifyWithLibraryReport(latestReport.result, bookLogInfo)
-          : nullifyWithLibraryReport(undefined, bookLogInfo);
+          : (isNew ? nullifyWithLibraryReport(undefined, bookLogInfo) : values);
+
       return (
         <FormContentContainer>
           <Form
@@ -112,7 +113,7 @@ const nullifyWithLibraryReport = (
     mostRecentShipmentYear: !!bookLogs.length ? parseInt(
       bookLogs.filter(log => log.count > 0)[0].date.toString().split(' ')[5],
       10,
-    ) : new Date().getFullYear(),
+    ) : null,
     visitReason: null,
     actionPlans: null,
     successStories: null,

--- a/src/components/report/ReportWithLibrary.tsx
+++ b/src/components/report/ReportWithLibrary.tsx
@@ -1,10 +1,13 @@
 import { Form, message } from 'antd';
 import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
 import {
   LibraryReportResponse,
   ReportWithLibraryRequest,
   Timetable,
 } from '../../containers/library-report/ducks/types';
+import { C4CState } from '../../store';
+import { AsyncRequest, AsyncRequestKinds } from '../../utils/asyncRequest';
 import FormContentContainer from '../form-style/FormContentContainer';
 import ChangesActionPlan from './common/ChangesActionPlan';
 import StudentBookInformation from './common/StudentBookInformation';
@@ -17,6 +20,7 @@ interface ReportWithLibraryProps {
   values?: LibraryReportResponse;
   editable: boolean;
   onSubmit: (values: ReportWithLibraryRequest) => void;
+  isNew: boolean;
 }
 
 const ReportWithLibrary: React.FC<ReportWithLibraryProps> = ({
@@ -24,10 +28,19 @@ const ReportWithLibrary: React.FC<ReportWithLibraryProps> = ({
   editable,
   onSubmit,
   children,
+  isNew
 }) => {
   const [visitReason, setVisitReason] = useState(values?.visitReason || null);
   const [timeTable, setTimeTable] = useState<Timetable | null>(null);
   const [showTimeTable, setShowTimeTable] = useState<boolean>(false);
+
+  const latestReport: AsyncRequest<
+    LibraryReportResponse,
+    any
+  > = useSelector(
+    (state: C4CState) =>
+      state.libraryReportState.latestReport,
+  );
 
   const handleSubmit = (submittedValues: ReportWithLibraryRequest) => {
     onSubmit({
@@ -39,38 +52,76 @@ const ReportWithLibrary: React.FC<ReportWithLibraryProps> = ({
       visitReason,
     });
   };
-
-  return (
-    <FormContentContainer>
-      <Form
-        initialValues={values}
-        onFinish={handleSubmit}
-        onFinishFailed={() =>
-          message.error(
-            'Error submitting form, please double check your responses and try again.',
-          )
-        }
-      >
-        <VisitReason
-          setVisitReason={setVisitReason}
-          visitReason={visitReason}
-          editable={editable}
-        />
-        <StudentBookInformation editable={editable} />
-        <LibraryInfo editable={editable} />
-        <MonitoringInfo
-          editable={editable}
-          showTimeTable={showTimeTable}
-          setShowTimeTable={setShowTimeTable}
-          timeTable={timeTable}
-          setTimeTable={setTimeTable}
-        />
-        <TrainingMentorshipInfo editable={editable} report={values} />
-        <ChangesActionPlan editable={editable} />
-        {children}
-      </Form>
-    </FormContentContainer>
-  );
+   
+   switch (latestReport.kind) {
+      case AsyncRequestKinds.NotStarted:
+      case AsyncRequestKinds.Failed:
+        return <p>An error occurred loading last report</p>;
+      case AsyncRequestKinds.Loading:
+        return <p>Loading school data</p>;
+      case AsyncRequestKinds.Completed:
+        return (
+          <FormContentContainer>
+            <Form
+              initialValues={isNew ? nullifyWithLibraryReport(latestReport.result) : values}
+              onFinish={handleSubmit}
+              onFinishFailed={() =>
+                message.error(
+                  'Error submitting form, please double check your responses and try again.',
+                )
+              }
+            >
+              <VisitReason
+                setVisitReason={setVisitReason}
+                visitReason={visitReason}
+                editable={editable}
+              />
+              <StudentBookInformation editable={editable} />
+              <LibraryInfo editable={editable} />
+              <MonitoringInfo
+                editable={editable}
+                showTimeTable={showTimeTable}
+                setShowTimeTable={setShowTimeTable}
+                timeTable={timeTable}
+                setTimeTable={setTimeTable}
+              />
+              <TrainingMentorshipInfo editable={editable} report={values} />
+              <ChangesActionPlan editable={editable} />
+              {children}
+            </Form>
+          </FormContentContainer>
+        );
+   }
 };
+
+const nullifyWithLibraryReport = (report: LibraryReportResponse | undefined): ReportWithLibraryRequest  | undefined => {
+  if (report === undefined) {
+    return undefined;
+  }
+  const reportRequest: ReportWithLibraryRequest = {
+    numberOfChildren: report.numberOfChildren,
+    gradesAttended: report.gradesAttended,
+    numberOfBooks: null, 
+    mostRecentShipmentYear: null, 
+    visitReason: null, 
+    actionPlans: null, 
+    successStories: null, 
+    isSharedSpace: null, 
+    hasInvitingSpace: null, 
+    assignedPersonRole: null, 
+    assignedPersonTitle: null, 
+    apprenticeshipProgram: null, 
+    trainsAndMentorsApprentices: null, 
+    hasCheckInTimetables: null, 
+    hasBookCheckoutSystem: null, 
+    numberOfStudentLibrarians: null, 
+    reasonNoStudentLibrarians: null, 
+    hasSufficientTraining: null, 
+    teacherSupport: null, 
+    parentSupport: null, 
+    timetable: null
+  }
+  return reportRequest;
+}
 
 export default ReportWithLibrary;

--- a/src/components/report/ReportWithLibrary.tsx
+++ b/src/components/report/ReportWithLibrary.tsx
@@ -56,13 +56,12 @@ const ReportWithLibrary: React.FC<ReportWithLibraryProps> = ({
     case AsyncRequestKinds.NotStarted:
     case AsyncRequestKinds.Loading:
       return <p>Loading school data</p>;
-
     case AsyncRequestKinds.Failed:
     case AsyncRequestKinds.Completed:
       const reportRequest =
         isNew && latestReport.kind === AsyncRequestKinds.Completed
           ? nullifyWithLibraryReport(latestReport.result, bookLogInfo)
-          : values;
+          : nullifyWithLibraryReport(undefined, bookLogInfo);
       return (
         <FormContentContainer>
           <Form
@@ -101,22 +100,19 @@ const nullifyWithLibraryReport = (
   report: LibraryReportResponse | undefined,
   bookLogs: BookLogResponse[],
 ): ReportWithLibraryRequest | undefined => {
-  if (report === undefined) {
-    return undefined;
-  }
   bookLogs.sort(
     (a, b) =>
       parseInt(b.date.toString().split(' ')[5], 10) -
       parseInt(a.date.toString().split(' ')[5], 10),
   );
   const reportRequest: ReportWithLibraryRequest = {
-    numberOfChildren: report.numberOfChildren,
-    gradesAttended: report.gradesAttended,
-    numberOfBooks: bookLogs.reduce((a, b) => a + b.count, 0),
-    mostRecentShipmentYear: parseInt(
-      bookLogs[0].date.toString().split(' ')[5],
+    numberOfChildren: !!report ? report.numberOfChildren : null,
+    gradesAttended: !!report ? report.gradesAttended : [],
+    numberOfBooks: !!bookLogs.length ? bookLogs.reduce((a, b) => a + b.count, 0) : 0,
+    mostRecentShipmentYear: !!bookLogs.length ? parseInt(
+      bookLogs.filter(log => log.count > 0)[0].date.toString().split(' ')[5],
       10,
-    ),
+    ) : new Date().getFullYear(),
     visitReason: null,
     actionPlans: null,
     successStories: null,

--- a/src/components/report/ReportWithoutLibrary.tsx
+++ b/src/components/report/ReportWithoutLibrary.tsx
@@ -46,12 +46,15 @@ const ReportWithoutLibrary: React.FC<ReportWithoutLibraryProps> = ({
 
   return (<>
     { (asyncRequestIsNotStarted(latestReport) || asyncRequestIsLoading(latestReport)) && <p>Loading school data...</p> }
-    { asyncRequestIsFailed(latestReport) && <p>Failed to load report</p>}
-    { asyncRequestIsComplete(latestReport) && <FormContentContainer>
+    { asyncRequestIsFailed(latestReport) && !isNew && <p>Failed to load report</p>}
+    { (asyncRequestIsComplete(latestReport) || asyncRequestIsFailed(latestReport)) && <FormContentContainer>
           <Form
             initialValues={
-              isNew
-                ? initializeNewReportForm(latestReport.result, bookLogInfo, false) as ReportWithoutLibraryRequest
+              isNew ? (initializeNewReportForm(
+                    asyncRequestIsComplete(latestReport) ? latestReport.result : values,
+                    bookLogInfo,
+                    true,
+                  ) as ReportWithoutLibraryRequest)
                 : values
             }
             onFinish={handleSubmit}

--- a/src/components/report/ReportWithoutLibrary.tsx
+++ b/src/components/report/ReportWithoutLibrary.tsx
@@ -29,7 +29,7 @@ const ReportWithoutLibrary: React.FC<ReportWithoutLibraryProps> = ({
   onSubmit,
   bookLogInfo,
   children,
-  isNew
+  isNew,
 }) => {
   const [visitReason, setVisitReason] = useState(values?.visitReason || null);
 
@@ -40,12 +40,8 @@ const ReportWithoutLibrary: React.FC<ReportWithoutLibraryProps> = ({
     });
   };
 
-  const latestReport: AsyncRequest<
-    LibraryReportResponse,
-    any
-  > = useSelector(
-    (state: C4CState) =>
-      state.libraryReportState.latestReport,
+  const latestReport: AsyncRequest<LibraryReportResponse, any> = useSelector(
+    (state: C4CState) => state.libraryReportState.latestReport,
   );
 
   switch (latestReport.kind) {
@@ -57,50 +53,64 @@ const ReportWithoutLibrary: React.FC<ReportWithoutLibraryProps> = ({
     case AsyncRequestKinds.Completed:
       return (
         <FormContentContainer>
-      <Form
-        initialValues={isNew ? nullifyWithoutLibraryReport(latestReport.result, bookLogInfo) : values}
-        onFinish={handleSubmit}
-        onFinishFailed={() =>
-          message.error(
-            'Error submitting form, please double check your responses and try again.',
-          )
-        }
-      >
-        <VisitReason
-          setVisitReason={setVisitReason}
-          visitReason={visitReason}
-          editable={editable}
-        />
-        <StudentBookInformation editable={editable} />
-        <LibraryInfo editable={editable} />
-        <ChangesActionPlan editable={editable} />
-        {children}
-      </Form>
-    </FormContentContainer>
+          <Form
+            initialValues={
+              isNew
+                ? nullifyWithoutLibraryReport(latestReport.result, bookLogInfo)
+                : values
+            }
+            onFinish={handleSubmit}
+            onFinishFailed={() =>
+              message.error(
+                'Error submitting form, please double check your responses and try again.',
+              )
+            }
+          >
+            <VisitReason
+              setVisitReason={setVisitReason}
+              visitReason={visitReason}
+              editable={editable}
+            />
+            <StudentBookInformation editable={editable} />
+            <LibraryInfo editable={editable} />
+            <ChangesActionPlan editable={editable} />
+            {children}
+          </Form>
+        </FormContentContainer>
       );
- }
+  }
 };
 
-const nullifyWithoutLibraryReport = (report: LibraryReportResponse | undefined, bookLogs: BookLogResponse[]): ReportWithoutLibraryRequest  | undefined => {
+const nullifyWithoutLibraryReport = (
+  report: LibraryReportResponse | undefined,
+  bookLogs: BookLogResponse[],
+): ReportWithoutLibraryRequest | undefined => {
   if (report === undefined) {
     return undefined;
   }
-  bookLogs.sort((a, b) => parseInt(b.date.toString().split(' ')[5]) - parseInt(a.date.toString().split(' ')[5]));
+  bookLogs.sort(
+    (a, b) =>
+      parseInt(b.date.toString().split(' ')[5], 10) -
+      parseInt(a.date.toString().split(' ')[5], 10),
+  );
   const reportRequest: ReportWithoutLibraryRequest = {
     numberOfChildren: report.numberOfChildren,
     gradesAttended: report.gradesAttended,
-    numberOfBooks: bookLogs.reduce((a, b) => a + b.count, 0), 
-    mostRecentShipmentYear: parseInt(bookLogs[0].date.toString().split(' ')[5]), 
-    visitReason: null, 
-    actionPlans: null, 
-    successStories: null, 
+    numberOfBooks: bookLogs.reduce((a, b) => a + b.count, 0),
+    mostRecentShipmentYear: parseInt(
+      bookLogs[0].date.toString().split(' ')[5],
+      10,
+    ),
+    visitReason: null,
+    actionPlans: null,
+    successStories: null,
     reason: null,
     wantsLibrary: null,
     hasSpace: null,
     currentStatus: null,
-    readyTimeline: ReadyTimeline.UPCOMING_SCHOOL_YEAR
-  }
+    readyTimeline: ReadyTimeline.UPCOMING_SCHOOL_YEAR,
+  };
   return reportRequest;
-}
+};
 
 export default ReportWithoutLibrary;

--- a/src/components/report/ReportWithoutLibrary.tsx
+++ b/src/components/report/ReportWithoutLibrary.tsx
@@ -13,11 +13,13 @@ import VisitReason from './common/VisitReason';
 import { AsyncRequest, AsyncRequestKinds } from '../../utils/asyncRequest';
 import { useSelector } from 'react-redux';
 import { C4CState } from '../../store';
+import { BookLogResponse } from '../../containers/bookLogs/ducks/types';
 
 interface ReportWithoutLibraryProps {
   values?: LibraryReportResponse;
   editable: boolean;
   onSubmit: (values: ReportWithoutLibraryRequest) => void;
+  bookLogInfo: BookLogResponse[];
   isNew: boolean;
 }
 
@@ -25,6 +27,7 @@ const ReportWithoutLibrary: React.FC<ReportWithoutLibraryProps> = ({
   values,
   editable,
   onSubmit,
+  bookLogInfo,
   children,
   isNew
 }) => {
@@ -45,9 +48,6 @@ const ReportWithoutLibrary: React.FC<ReportWithoutLibraryProps> = ({
       state.libraryReportState.latestReport,
   );
 
-  // useEffect(() => {
-  //   form.setFieldsValue(initialValues)
-  //  }, [form, initialValues]);
   switch (latestReport.kind) {
     case AsyncRequestKinds.NotStarted:
     case AsyncRequestKinds.Failed:
@@ -58,7 +58,7 @@ const ReportWithoutLibrary: React.FC<ReportWithoutLibraryProps> = ({
       return (
         <FormContentContainer>
       <Form
-        initialValues={isNew ? nullifyWithoutLibraryReport(latestReport.result) : values}
+        initialValues={isNew ? nullifyWithoutLibraryReport(latestReport.result, bookLogInfo) : values}
         onFinish={handleSubmit}
         onFinishFailed={() =>
           message.error(
@@ -81,15 +81,16 @@ const ReportWithoutLibrary: React.FC<ReportWithoutLibraryProps> = ({
  }
 };
 
-const nullifyWithoutLibraryReport = (report: LibraryReportResponse | undefined): ReportWithoutLibraryRequest  | undefined => {
+const nullifyWithoutLibraryReport = (report: LibraryReportResponse | undefined, bookLogs: BookLogResponse[]): ReportWithoutLibraryRequest  | undefined => {
   if (report === undefined) {
     return undefined;
   }
+  bookLogs.sort((a, b) => parseInt(b.date.toString().split(' ')[5]) - parseInt(a.date.toString().split(' ')[5]));
   const reportRequest: ReportWithoutLibraryRequest = {
     numberOfChildren: report.numberOfChildren,
     gradesAttended: report.gradesAttended,
-    numberOfBooks: null, 
-    mostRecentShipmentYear: null, 
+    numberOfBooks: bookLogs.reduce((a, b) => a + b.count, 0), 
+    mostRecentShipmentYear: parseInt(bookLogs[0].date.toString().split(' ')[5]), 
     visitReason: null, 
     actionPlans: null, 
     successStories: null, 

--- a/src/components/report/common/StudentBookInformation.tsx
+++ b/src/components/report/common/StudentBookInformation.tsx
@@ -20,7 +20,6 @@ interface StudentBookInformationProps {
 const StudentBookInformation: React.FC<StudentBookInformationProps> = ({
   editable,
 }) => {
-
   const gradeOptions = Object.entries(Grade).map(([key, value]) => ({
     label: toTitleCase(key.replace('_', ' ')),
     value,
@@ -33,7 +32,7 @@ const StudentBookInformation: React.FC<StudentBookInformationProps> = ({
           <FormPiece note="How Many Children attended?">
             <Form.Item name="numberOfChildren">
               {editable ? (
-                <InputNumberNoArrows placeholder="#" min={0}/>
+                <InputNumberNoArrows placeholder="#" min={0} />
               ) : (
                 <FormText />
               )}
@@ -56,7 +55,7 @@ const StudentBookInformation: React.FC<StudentBookInformationProps> = ({
         <Col span={12}>
           <FormPiece note="What grades attended?">
             <Form.Item name="gradesAttended">
-              <Checkbox.Group disabled={!editable} options={gradeOptions}/>
+              <Checkbox.Group disabled={!editable} options={gradeOptions} />
             </Form.Item>
           </FormPiece>
         </Col>

--- a/src/components/report/common/StudentBookInformation.tsx
+++ b/src/components/report/common/StudentBookInformation.tsx
@@ -20,6 +20,7 @@ interface StudentBookInformationProps {
 const StudentBookInformation: React.FC<StudentBookInformationProps> = ({
   editable,
 }) => {
+
   const gradeOptions = Object.entries(Grade).map(([key, value]) => ({
     label: toTitleCase(key.replace('_', ' ')),
     value,
@@ -32,7 +33,7 @@ const StudentBookInformation: React.FC<StudentBookInformationProps> = ({
           <FormPiece note="How Many Children attended?">
             <Form.Item name="numberOfChildren">
               {editable ? (
-                <InputNumberNoArrows placeholder="#" min={0} />
+                <InputNumberNoArrows placeholder="#" min={0}/>
               ) : (
                 <FormText />
               )}
@@ -43,7 +44,7 @@ const StudentBookInformation: React.FC<StudentBookInformationProps> = ({
           <FormPiece note="How Many Books?">
             <Form.Item name="numberOfBooks">
               {editable ? (
-                <InputNumberNoArrows placeholder="#" min={0} />
+                <InputNumberNoArrows placeholder="#" min={0} disabled />
               ) : (
                 <FormText />
               )}
@@ -55,7 +56,7 @@ const StudentBookInformation: React.FC<StudentBookInformationProps> = ({
         <Col span={12}>
           <FormPiece note="What grades attended?">
             <Form.Item name="gradesAttended">
-              <Checkbox.Group disabled={!editable} options={gradeOptions} />
+              <Checkbox.Group disabled={!editable} options={gradeOptions}/>
             </Form.Item>
           </FormPiece>
         </Col>
@@ -63,7 +64,7 @@ const StudentBookInformation: React.FC<StudentBookInformationProps> = ({
           <FormPiece note="Most recent shipment year?">
             <Form.Item name="mostRecentShipmentYear">
               {editable ? (
-                <InputNumberNoArrows placeholder="#" min={0} />
+                <InputNumberNoArrows placeholder="#" min={0} disabled />
               ) : (
                 <FormText />
               )}

--- a/src/containers/library-report/NewLibraryReport.tsx
+++ b/src/containers/library-report/NewLibraryReport.tsx
@@ -1,5 +1,5 @@
 import { message } from 'antd';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import protectedApiClient from '../../api/protectedApiClient';
@@ -27,6 +27,13 @@ const NewLibraryReport = () => {
   if (!schoolId) {
     history.replace(Routes.HOME);
   }
+
+  useEffect(() => {
+    if (schoolId !== undefined) {
+      dispatch(loadLatestLibraryReport(schoolId));
+    }
+  }, [schoolId, dispatch])
+
 
   const handleSubmit = async (
     report: ReportWithLibraryRequest | ReportWithoutLibraryRequest,
@@ -59,11 +66,12 @@ const NewLibraryReport = () => {
       <FormButtons.Button text="Submit" type="primary" isSubmit={true} />
     </FormButtons>
   );
-
+  
   const props = {
     editable: true,
     onSubmit: handleSubmit,
     children: buttons,
+    isNew: true
   };
 
   return isYesReport ? (

--- a/src/containers/library-report/NewLibraryReport.tsx
+++ b/src/containers/library-report/NewLibraryReport.tsx
@@ -25,12 +25,8 @@ const NewLibraryReport = () => {
   const schoolId = useSelector(
     (state: C4CState) => state.selectSchoolState.selectedSchoolId,
   );
-  const bookLogs: AsyncRequest<
-    BookLogResponse[],
-    any
-  > = useSelector(
-    (state: C4CState) =>
-      state.bookLogsState.bookLogs,
+  const bookLogs: AsyncRequest<BookLogResponse[], any> = useSelector(
+    (state: C4CState) => state.bookLogsState.bookLogs,
   );
   const history = useHistory();
 
@@ -43,7 +39,7 @@ const NewLibraryReport = () => {
       dispatch(loadLatestLibraryReport(schoolId));
       dispatch(getBookLogs(schoolId));
     }
-  }, [schoolId, dispatch])
+  }, [schoolId, dispatch]);
 
   const handleSubmit = async (
     report: ReportWithLibraryRequest | ReportWithoutLibraryRequest,
@@ -89,7 +85,7 @@ const NewLibraryReport = () => {
         onSubmit: handleSubmit,
         children: buttons,
         bookLogInfo: bookLogs.result,
-        isNew: true
+        isNew: true,
       };
       return isYesReport ? (
         <ReportWithLibrary {...props} />

--- a/src/containers/library-report/ducks/thunks.ts
+++ b/src/containers/library-report/ducks/thunks.ts
@@ -7,7 +7,7 @@ export const loadLatestLibraryReport = (
   return (dispatch, _getState, { protectedApiClient }) => {
     dispatch(latestLibraryReport.loading());
     return protectedApiClient
-      .getLatestReport(schoolId)
+      .getLatestReportWithLibrary(schoolId)
       .then((response: LibraryReportResponse) => {
         dispatch(latestLibraryReport.loaded(response));
       })

--- a/src/containers/library-report/ducks/types.ts
+++ b/src/containers/library-report/ducks/types.ts
@@ -23,6 +23,7 @@ export interface LibraryReportShared {
   visitReason: null | string;
   readonly actionPlans: null | string;
   readonly successStories: null | string;
+  readonly gradesAttended: string[];
 }
 
 export interface ReportWithLibraryRequest extends LibraryReportShared {

--- a/src/containers/library-report/tests/thunks.test.ts
+++ b/src/containers/library-report/tests/thunks.test.ts
@@ -22,6 +22,7 @@ describe('Report With Library Thunks', () => {
         updatedAt: '',
         userId: 3,
         schoolId: 1,
+        gradesAttended: [],
         libraryStatus: 'EXISTS',
         numberOfChildren: null,
         numberOfBooks: null,

--- a/src/containers/library-report/tests/thunks.test.ts
+++ b/src/containers/library-report/tests/thunks.test.ts
@@ -50,7 +50,7 @@ describe('Report With Library Thunks', () => {
       const mockExtraArgs: ApiExtraArgs = {
         protectedApiClient: {
           ...protectedApiClient,
-          getLatestReport: mockGetReportWithLibrary,
+          getLatestReportWithLibrary: mockGetReportWithLibrary,
         },
       };
 
@@ -78,7 +78,7 @@ describe('Report With Library Thunks', () => {
       const mockExtraArgs: ThunkExtraArgs = generateExtraArgs({
         protectedApiClient: {
           ...protectedApiClient,
-          getLatestReport: mockGetReportWithLibrary,
+          getLatestReportWithLibrary: mockGetReportWithLibrary,
         },
       });
 

--- a/src/containers/pastSubmissionsReports/EditLibraryReport.tsx
+++ b/src/containers/pastSubmissionsReports/EditLibraryReport.tsx
@@ -13,9 +13,9 @@ import { setActiveReport } from './ducks/actions';
 import FormButtons from '../../components/form-style/FormButtons';
 import ReportWithLibrary from '../../components/report/ReportWithLibrary';
 import ReportWithoutLibrary from '../../components/report/ReportWithoutLibrary';
-import { AsyncRequest, AsyncRequestKinds } from '../../utils/asyncRequest';
 import { BookLogResponse } from '../bookLogs/ducks/types';
 import { getBookLogs } from '../bookLogs/ducks/thunks';
+import { AsyncRequest, asyncRequestIsComplete, asyncRequestIsFailed, asyncRequestIsLoading, asyncRequestIsNotStarted } from '../../utils/asyncRequest';
 
 const EditLibraryReport: React.FC = () => {
   const dispatch = useDispatch();
@@ -90,27 +90,13 @@ const EditLibraryReport: React.FC = () => {
     </FormButtons>
   );
 
-  switch (bookLogs.kind) {
-    case AsyncRequestKinds.NotStarted:
-    case AsyncRequestKinds.Failed:
-      return <p>An error occurred loading school info</p>;
-    case AsyncRequestKinds.Loading:
-      return <p>Loading school data</p>;
-    case AsyncRequestKinds.Completed:
-      const props = {
-        editable: true,
-        onSubmit: handleSubmit,
-        children: buttons,
-        bookLogInfo: bookLogs.result,
-        values: report,
-        isNew: false,
-      };
-      return isYesReport ? (
-        <ReportWithLibrary {...props} />
-      ) : (
-        <ReportWithoutLibrary {...props} />
-      );
-  }
+  return (<>
+    { (asyncRequestIsNotStarted(bookLogs) || asyncRequestIsLoading(bookLogs)) && <p>Loading school data...</p> }
+    { asyncRequestIsFailed(bookLogs) && <p>Failed to load report data</p>}
+    { asyncRequestIsComplete(bookLogs) && (isYesReport 
+      ? <ReportWithLibrary isNew={false} children={buttons} bookLogInfo={bookLogs.result} editable={true} onSubmit={handleSubmit} values={report} /> 
+      : <ReportWithoutLibrary isNew={false} children={buttons} bookLogInfo={bookLogs.result} editable={true} onSubmit={handleSubmit} values={report} /> )}
+  </>);
 };
 
 export default EditLibraryReport;

--- a/src/containers/pastSubmissionsReports/EditLibraryReport.tsx
+++ b/src/containers/pastSubmissionsReports/EditLibraryReport.tsx
@@ -83,6 +83,7 @@ const EditLibraryReport: React.FC = () => {
     editable: editMode,
     children: buttons,
     onSubmit: handleSubmit,
+    isNew: false
   };
 
   return isYesReport ? (

--- a/src/containers/pastSubmissionsReports/EditLibraryReport.tsx
+++ b/src/containers/pastSubmissionsReports/EditLibraryReport.tsx
@@ -103,7 +103,7 @@ const EditLibraryReport: React.FC = () => {
         children: buttons,
         bookLogInfo: bookLogs.result,
         values: report,
-        isNew: true,
+        isNew: false,
       };
       return isYesReport ? (
         <ReportWithLibrary {...props} />

--- a/src/containers/pastSubmissionsReports/EditLibraryReport.tsx
+++ b/src/containers/pastSubmissionsReports/EditLibraryReport.tsx
@@ -22,12 +22,8 @@ const EditLibraryReport: React.FC = () => {
   const report = useSelector(
     (state: C4CState) => state.pastSubmissionReportsState.activeReport,
   );
-  const bookLogs: AsyncRequest<
-    BookLogResponse[],
-    any
-  > = useSelector(
-    (state: C4CState) =>
-      state.bookLogsState.bookLogs,
+  const bookLogs: AsyncRequest<BookLogResponse[], any> = useSelector(
+    (state: C4CState) => state.bookLogsState.bookLogs,
   );
   const history = useHistory();
   const isYesReport = report && report.libraryStatus === 'EXISTS';
@@ -107,7 +103,7 @@ const EditLibraryReport: React.FC = () => {
         children: buttons,
         bookLogInfo: bookLogs.result,
         values: report,
-        isNew: true
+        isNew: true,
       };
       return isYesReport ? (
         <ReportWithLibrary {...props} />

--- a/src/utils/reportForm.ts
+++ b/src/utils/reportForm.ts
@@ -1,32 +1,29 @@
 import { BookLogResponse } from '../containers/bookLogs/ducks/types';
 import {
-  LibraryReportResponse,
+  LibraryReportShared,
   ReadyTimeline,
   ReportWithLibraryRequest,
   ReportWithoutLibraryRequest,
 } from '../containers/library-report/ducks/types';
 
 export const initializeNewReportForm = (
-  report: LibraryReportResponse | undefined,
+  report:  LibraryReportShared | undefined,
   bookLogs: BookLogResponse[],
   hasLibrary: boolean,
 ): ReportWithLibraryRequest | ReportWithoutLibraryRequest | undefined => {
-  if (report === undefined) {
-    return undefined;
-  }
   bookLogs.sort(
     (a, b) =>
       parseInt(b.date.toString().split(' ')[5], 10) -
       parseInt(a.date.toString().split(' ')[5], 10),
   );
-  const filledInValues = {
-    numberOfChildren: report.numberOfChildren,
-    gradesAttended: report.gradesAttended,
+  let filledInValues = {
+    numberOfChildren: report === undefined ? null : report.numberOfChildren,
+    gradesAttended: report === undefined ? [] : report.gradesAttended,
     numberOfBooks: bookLogs.reduce((a, b) => a + b.count, 0),
-    mostRecentShipmentYear: parseInt(
+    mostRecentShipmentYear: bookLogs.length > 0 ? parseInt(
       bookLogs[0].date.toString().split(' ')[5],
       10,
-    ),
+    ) : null,
   };
   if (hasLibrary) {
     const reportRequest: ReportWithLibraryRequest = {

--- a/src/utils/reportForm.ts
+++ b/src/utils/reportForm.ts
@@ -1,0 +1,67 @@
+import { BookLogResponse } from '../containers/bookLogs/ducks/types';
+import {
+  LibraryReportResponse,
+  ReadyTimeline,
+  ReportWithLibraryRequest,
+  ReportWithoutLibraryRequest,
+} from '../containers/library-report/ducks/types';
+
+export const initializeNewReportForm = (
+  report: LibraryReportResponse | undefined,
+  bookLogs: BookLogResponse[],
+  hasLibrary: boolean,
+): ReportWithLibraryRequest | ReportWithoutLibraryRequest | undefined => {
+  if (report === undefined) {
+    return undefined;
+  }
+  bookLogs.sort(
+    (a, b) =>
+      parseInt(b.date.toString().split(' ')[5], 10) -
+      parseInt(a.date.toString().split(' ')[5], 10),
+  );
+  const filledInValues = {
+    numberOfChildren: report.numberOfChildren,
+    gradesAttended: report.gradesAttended,
+    numberOfBooks: bookLogs.reduce((a, b) => a + b.count, 0),
+    mostRecentShipmentYear: parseInt(
+      bookLogs[0].date.toString().split(' ')[5],
+      10,
+    ),
+  };
+  if (hasLibrary) {
+    const reportRequest: ReportWithLibraryRequest = {
+      ...filledInValues,
+      visitReason: null,
+      actionPlans: null,
+      successStories: null,
+      isSharedSpace: null,
+      hasInvitingSpace: null,
+      assignedPersonRole: null,
+      assignedPersonTitle: null,
+      apprenticeshipProgram: null,
+      trainsAndMentorsApprentices: null,
+      hasCheckInTimetables: null,
+      hasBookCheckoutSystem: null,
+      numberOfStudentLibrarians: null,
+      reasonNoStudentLibrarians: null,
+      hasSufficientTraining: null,
+      teacherSupport: null,
+      parentSupport: null,
+      timetable: null,
+    };
+    return reportRequest;
+  } else {
+    const reportRequest: ReportWithoutLibraryRequest = {
+      ...filledInValues,
+      visitReason: null,
+      actionPlans: null,
+      successStories: null,
+      reason: null,
+      wantsLibrary: null,
+      hasSpace: null,
+      currentStatus: null,
+      readyTimeline: ReadyTimeline.UPCOMING_SCHOOL_YEAR,
+    };
+    return reportRequest;
+  }
+};


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/866744728/pulses/1500401992)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

Displays the current number of students and grades attended in the report by default (pulling this information from the previous report if there was one. Also displays the total number of books and the most recent shipment year from the school's book logs data. 

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

Pretty straightforward, just getting this information from redux. One thing to note is that the most recent shipment year has to be the most recent shipment year from a book log that had a positive number of books, which is why I filtered it out before adding the shipment year.

This PR is also blocked by [this ticket](https://code4community-team.monday.com/boards/866744728/pulses/1543664620) since for cases where a school has no book logs, the shipment year will be null and this will get a bad request when you try to submit the form. So once that's merged and deployed I'll be able to merge this PR 

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 

<img width="995" alt="Screen Shot 2021-08-04 at 8 56 05 AM" src="https://user-images.githubusercontent.com/36246323/128184479-b584ad69-800f-430d-a007-fd5a6cc5f931.png">


## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 

Npm start, go to "Fill out a form". Pick a school that already has a report and go through the form and the book/grade values should show up. After that you can go to the book logs tab, add a book log or two for that school, and then go through the form again and then those values will show up. 
