### PR TITLE
Fixed Training & Mentorship buttons highlighting on initial form submit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9674,6 +9674,7 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -18305,6 +18306,7 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -18662,6 +18664,7 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/src/components/report/withLibrary/TrainingMentorshipInfo.tsx
+++ b/src/components/report/withLibrary/TrainingMentorshipInfo.tsx
@@ -17,14 +17,20 @@ const TrainingMentorshipInfo: React.FC<TrainingMentorshipInfoProps> = ({
 }) => {
   const numStudentLibrarians =
     report?.libraryStatus === 'EXISTS' && report?.numberOfStudentLibrarians;
-  const [isStudentLibrary, setIsStudentLibrary] = useState<boolean>(
-    !!numStudentLibrarians,
+  const [isStudentLibrary, setIsStudentLibrary] = useState<boolean | undefined>(
+    report ? !!numStudentLibrarians : undefined,
   );
-  const [involvedParents, setInvolvedParents] = useState<boolean>(
-    report?.libraryStatus === 'EXISTS' && !!report?.parentSupport,
+  const [involvedParents, setInvolvedParents] = useState<boolean | undefined>(
+    report
+      ? report?.libraryStatus === 'EXISTS' && !!report?.parentSupport
+      : undefined,
   );
-  const [teachersSeekingSupport, setTeacherSeekingSupport] = useState<boolean>(
-    report?.libraryStatus === 'EXISTS' && !!report?.teacherSupport,
+  const [teachersSeekingSupport, setTeacherSeekingSupport] = useState<
+    boolean | undefined
+  >(
+    report
+      ? report?.libraryStatus === 'EXISTS' && !!report?.teacherSupport
+      : undefined,
   );
 
   const handleChangeStudentLibrarians = (event: RadioChangeEvent) => {


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/866744728/pulses/1500407335

Previously, some of the yes/no boolean piece values would be highlighted before user has actually selected an option.

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

## This PR

Now, yes/no buttons are not selected by default.

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

## Verification Steps

Go to fill out a new form (with library), scroll down to training & mentorship section, verify no yes/no buttons are selected by default.