### PR TITLE
updated form history button/page for admin users

### DIFF
--- a/src/containers/home/index.tsx
+++ b/src/containers/home/index.tsx
@@ -8,8 +8,7 @@ import {
   PoweroffOutlined,
   UserOutlined,
   DatabaseOutlined,
-  TeamOutlined,
-  BulbOutlined,
+  TeamOutlined
 } from '@ant-design/icons';
 import { Routes } from '../../App';
 import { useHistory } from 'react-router-dom';

--- a/src/containers/home/index.tsx
+++ b/src/containers/home/index.tsx
@@ -218,77 +218,40 @@ const Home: React.FC = () => {
             </Row>
           )}
           <Row gutter={[32, 0]} wrap>
-            {privilegeLevel === PrivilegeLevel.ADMIN ? (
-              <Col span={12}>
-                <InContain
-                  lastPiece
-                  onClick={() => {
-                    history.push(Routes.PAST_SUBMISSIONS_SCHOOLS);
-                  }}
-                >
-                  <Row>
-                    <Col span={8}>
-                      <BulbOutlined
-                        style={{
-                          fontSize: '50px',
-                          marginTop: '14px',
-                          marginLeft: '5px',
-                        }}
-                      />
-                    </Col>
-                    <Col span={16}>
-                      <Row>
-                        <Col>
-                          <ButtonDescription level={3}>
-                            Data Insights
-                          </ButtonDescription>
-                        </Col>
-                      </Row>
-                      <Row>
-                        <Col>
-                          <Paragraph>View past forms</Paragraph>
-                        </Col>
-                      </Row>
-                    </Col>
-                  </Row>
-                </InContain>
-              </Col>
-            ) : (
-              <Col span={12}>
-                <InContain
-                  lastPiece
-                  onClick={() => {
-                    history.push(Routes.PAST_SUBMISSIONS_SCHOOLS);
-                  }}
-                >
-                  <Row>
-                    <Col span={8}>
-                      <FolderOpenOutlined
-                        style={{
-                          fontSize: '50px',
-                          marginTop: '14px',
-                          marginLeft: '5px',
-                        }}
-                      />
-                    </Col>
-                    <Col span={16}>
-                      <Row>
-                        <Col>
-                          <ButtonDescription level={3}>
-                            Form History
-                          </ButtonDescription>
-                        </Col>
-                      </Row>
-                      <Row>
-                        <Col>
-                          <Paragraph>View past forms</Paragraph>
-                        </Col>
-                      </Row>
-                    </Col>
-                  </Row>
-                </InContain>
-              </Col>
-            )}
+            <Col span={12}>
+              <InContain
+                lastPiece
+                onClick={() => {
+                  history.push(Routes.PAST_SUBMISSIONS_SCHOOLS);
+                }}
+              >
+                <Row>
+                  <Col span={8}>
+                    <FolderOpenOutlined
+                      style={{
+                        fontSize: '50px',
+                        marginTop: '14px',
+                        marginLeft: '5px',
+                      }}
+                    />
+                  </Col>
+                  <Col span={16}>
+                    <Row>
+                      <Col>
+                        <ButtonDescription level={3}>
+                          Form History
+                        </ButtonDescription>
+                      </Col>
+                    </Row>
+                    <Row>
+                      <Col>
+                        <Paragraph>View past forms</Paragraph>
+                      </Col>
+                    </Row>
+                  </Col>
+                </Row>
+              </InContain>
+            </Col>
             <Col span={12}>
               <InContain
                 lastPiece

--- a/src/containers/pastSubmissionsSchools/PastSubmissionsSchools.tsx
+++ b/src/containers/pastSubmissionsSchools/PastSubmissionsSchools.tsx
@@ -16,6 +16,7 @@ import Loading from '../../components/Loading';
 import { setPastSubmissionsSchoolId } from './ducks/actions';
 import { Routes } from '../../App';
 import { useHistory } from 'react-router';
+import { SchoolEntry } from '../selectSchool/ducks/types';
 
 interface SelectPasSubmissionSchoolForm {
   pastSubmissionsSchoolId: number;
@@ -25,12 +26,15 @@ const PastSubmissionsSchools: React.FC = (props) => {
   const dispatch = useDispatch();
   const history = useHistory();
 
-  const availableSchools: AsyncRequest<
-    PastSubmissionsSchoolsResponse,
-    any
-  > = useSelector(
-    (state: C4CState) =>
-      state.pastSubmissionSchoolsState.pastSubmissionsSchools,
+  // const availableSchools: AsyncRequest<
+  //   PastSubmissionsSchoolsResponse,
+  //   any
+  // > = useSelector(
+  //   (state: C4CState) =>
+  //     state.pastSubmissionSchoolsState.pastSubmissionsSchools,
+  // );
+  const availableSchools: AsyncRequest<SchoolEntry[], any> = useSelector(
+    (state: C4CState) => state.selectSchoolState.schools,
   );
 
   useEffect(() => {
@@ -86,7 +90,7 @@ const PastSubmissionsSchools: React.FC = (props) => {
                             .localeCompare(optionB.children.toLowerCase())
                         }
                       >
-                        {Array.from(availableSchools.result.schools).map(
+                        {Array.from(availableSchools.result).map(
                           renderSchoolOption,
                         )}
                       </Select>

--- a/src/containers/pastSubmissionsSchools/PastSubmissionsSchools.tsx
+++ b/src/containers/pastSubmissionsSchools/PastSubmissionsSchools.tsx
@@ -4,7 +4,6 @@ import { Col, Form, Row, Select } from 'antd';
 import { useDispatch, useSelector } from 'react-redux';
 import { AsyncRequest, AsyncRequestKinds } from '../../utils/asyncRequest';
 import { C4CState } from '../../store';
-import { getPastSubmissionsSchools } from './ducks/thunks';
 import { SchoolSummaryResponse } from './ducks/types';
 import FormContentContainer from '../../components/form-style/FormContentContainer';
 import FormPiece from '../../components/form-style/FormPiece';
@@ -14,6 +13,7 @@ import { setPastSubmissionsSchoolId } from './ducks/actions';
 import { Routes } from '../../App';
 import { useHistory } from 'react-router';
 import { SchoolEntry } from '../selectSchool/ducks/types';
+import { loadSchools } from '../selectSchool/ducks/thunks';
 
 interface SelectPasSubmissionSchoolForm {
   pastSubmissionsSchoolId: number;
@@ -23,19 +23,12 @@ const PastSubmissionsSchools: React.FC = (props) => {
   const dispatch = useDispatch();
   const history = useHistory();
 
-  // const availableSchools: AsyncRequest<
-  //   PastSubmissionsSchoolsResponse,
-  //   any
-  // > = useSelector(
-  //   (state: C4CState) =>
-  //     state.pastSubmissionSchoolsState.pastSubmissionsSchools,
-  // );
   const availableSchools: AsyncRequest<SchoolEntry[], any> = useSelector(
     (state: C4CState) => state.selectSchoolState.schools,
   );
 
   useEffect(() => {
-    dispatch(getPastSubmissionsSchools());
+    dispatch(loadSchools());
   }, [dispatch]);
 
   const renderSchoolOption = (school: SchoolSummaryResponse) => (

--- a/src/containers/pastSubmissionsSchools/PastSubmissionsSchools.tsx
+++ b/src/containers/pastSubmissionsSchools/PastSubmissionsSchools.tsx
@@ -5,10 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { AsyncRequest, AsyncRequestKinds } from '../../utils/asyncRequest';
 import { C4CState } from '../../store';
 import { getPastSubmissionsSchools } from './ducks/thunks';
-import {
-  PastSubmissionsSchoolsResponse,
-  SchoolSummaryResponse,
-} from './ducks/types';
+import { SchoolSummaryResponse } from './ducks/types';
 import FormContentContainer from '../../components/form-style/FormContentContainer';
 import FormPiece from '../../components/form-style/FormPiece';
 import FormButtons from '../../components/form-style/FormButtons';

--- a/src/containers/selectSchool/SelectSchool.tsx
+++ b/src/containers/selectSchool/SelectSchool.tsx
@@ -4,7 +4,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router';
 import ProtectedApiClient from '../../api/protectedApiClient';
 import { Routes } from '../../App';
-import { getUserID } from '../../auth/ducks/selectors';
+import { getPrivilegeLevel, getUserID } from '../../auth/ducks/selectors';
+import { PrivilegeLevel } from '../../auth/ducks/types';
 import FormButtons from '../../components/form-style/FormButtons';
 import FormContainer from '../../components/form-style/FormContainer';
 import FormContentContainer from '../../components/form-style/FormContentContainer';
@@ -32,6 +33,10 @@ const SelectSchool: React.FC = () => {
   );
   const userId = useSelector((state: C4CState) => {
     return getUserID(state.authenticationState.tokens);
+  });
+
+  const privilegeLevel: PrivilegeLevel = useSelector((state: C4CState) => {
+    return getPrivilegeLevel(state.authenticationState.tokens);
   });
 
   useEffect(() => {
@@ -95,7 +100,9 @@ const SelectSchool: React.FC = () => {
                       >
                         {Array.from(
                           availableSchools.result.filter(
-                            (school) => school.country === userInfo.country,
+                            (school) =>
+                              privilegeLevel === PrivilegeLevel.ADMIN ||
+                              school.country === userInfo.country,
                           ),
                         ).map(renderSchoolOption)}
                       </Select>


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/866744728/pulses/1500412688)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

Updates for the form history button/page for admin users. Changes the form history button to match the staff one, and allows the admin user to select from all schools, regardless of what country their account is associated with. Also updates the submit a form page for admins to allow them to select any school. 

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

see above, pretty straightforward implementation. 

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 

<img width="1074" alt="Screen Shot 2021-08-09 at 12 44 44 PM" src="https://user-images.githubusercontent.com/36246323/128743573-a3de9a61-d753-4c63-ad5e-505b6e5f668c.png">


<img width="852" alt="Screen Shot 2021-08-09 at 12 44 34 PM" src="https://user-images.githubusercontent.com/36246323/128743587-9efa59db-2ea5-4c11-a33e-86f3a1b1aaa2.png">


## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 

npm start and log in with an admin user. Then, click on the form history button and see if all schools are being displayed. Click on one that has reports, and all reports for that school will show up