### PR TITLE
updated logout logic

### DIFF
--- a/src/auth/ducks/thunks.ts
+++ b/src/auth/ducks/thunks.ts
@@ -45,7 +45,7 @@ export const signup = (
   };
 };
 
-export const logout = (): UserAuthenticationThunkAction<void> => {
+export const logout = (goToLogin: () => void): UserAuthenticationThunkAction<void> => {
   return (dispatch, getState, { authClient }): Promise<void> => {
     localStorage.removeItem(LOCALSTORAGE_STATE_KEY);
 
@@ -58,12 +58,14 @@ export const logout = (): UserAuthenticationThunkAction<void> => {
         .logout(refreshToken)
         .then(() => {
           dispatch(logoutUser.loaded());
+          goToLogin();
         })
         .catch(() => {
           dispatch(logoutUser.failed());
         });
     } else {
       dispatch(logoutUser.loaded());
+      goToLogin();
       return Promise.resolve();
     }
   };

--- a/src/containers/home/index.tsx
+++ b/src/containers/home/index.tsx
@@ -70,6 +70,11 @@ const Home: React.FC = () => {
     return getPrivilegeLevel(state.authenticationState.tokens);
   });
 
+  const goToLoginPage: () => void = () => {
+    history.replace(Routes.LOGIN);
+    history.go(0);
+  }
+
   return (
     <>
       <Helmet>
@@ -293,9 +298,7 @@ const Home: React.FC = () => {
               <InContain
                 lastPiece
                 onClick={() => {
-                  dispatch(logout());
-                  history.replace(Routes.LOGIN);
-                  history.go(0);
+                  dispatch(logout(goToLoginPage));
                 }}
               >
                 <Row>


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/XXXXXXXX/pulses/XXXXXXX)
#49 

Fixes the duplicate logout (I think)

## This PR

I'm pretty sure the issue with why this was happening was bc of something similar to a race condition. So, instead of calling the logout function, and then calling the history.push/history.go, what my changes do is add a callback function to be used in the actual thunk, so that no matter what the history functions are called after the logout is completed. 

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 
n/a

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 

npm start and log in and try to log out. I tested on chrome, firefox, and safari with admin and regular users so I think this should be fixed
