### PR TITLE
Add custom empty message for no school data found

### DIFF
--- a/src/containers/selectSchool/SelectSchool.tsx
+++ b/src/containers/selectSchool/SelectSchool.tsx
@@ -1,4 +1,4 @@
-import { Col, Form, Row, Select } from 'antd';
+import { Col, Form, Row, Select, Empty } from 'antd';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router';
@@ -96,6 +96,11 @@ const SelectSchool: React.FC = () => {
                           optionA.children
                             .toLowerCase()
                             .localeCompare(optionB.children.toLowerCase())
+                        }
+                        notFoundContent={
+                          <Empty
+                            description={<span>No School Data Found</span>}
+                          />
                         }
                       >
                         {Array.from(


### PR DESCRIPTION
## Why
https://app.clickup.com/t/1kafpdh

## This PR
Add a custom no data found message so it is clear to the user that the select menu has loaded, there is just no school data available.

Open to feedback if there's a clearer way to put it than "No School Data Found".

## Screenshots
<img width="1439" alt="Screen Shot 2021-10-03 at 10 12 10 AM" src="https://user-images.githubusercontent.com/55663537/135757741-84d9e4e4-1f85-4802-a199-e7d66332bd30.png">
