### PR TITLE
fboth school info and school edit functionalities refill values after…

### DIFF
--- a/src/components/schoolContact/SchoolContact.tsx
+++ b/src/components/schoolContact/SchoolContact.tsx
@@ -3,7 +3,7 @@ import {
   SchoolContactRequest,
   SchoolContactResponse,
 } from '../../containers/schoolContact/ducks/types';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button, Form, Input, Row, Select } from 'antd';
 import FormPiece from '../form-style/FormPiece';
 
@@ -24,13 +24,19 @@ const SchoolContact: React.FC<SchoolContactProps> = ({
   isFirst,
 }) => {
   const [editMode, setEditMode] = useState<boolean>(!initialSchoolContact);
+  const [form] = Form.useForm()
 
-  const onSubmitHandler = (c: SchoolContactRequest) => {
-    onSubmit(c);
+  useEffect(() => {
+    form.setFieldsValue(initialSchoolContact);
+  }, [form, initialSchoolContact]);
+
+  const onSubmitHandler = () => {
+    onSubmit(form.getFieldsValue());
     setEditMode(false);
   };
 
   const onCancelHandler = () => {
+    form.setFieldsValue(initialSchoolContact)
     if (initialSchoolContact) {
       setEditMode(false);
     } else if (onCancel !== undefined) {
@@ -40,9 +46,8 @@ const SchoolContact: React.FC<SchoolContactProps> = ({
 
   return (
     <Form
-      initialValues={initialSchoolContact}
+      form={form}
       name="school-contact"
-      onFinish={onSubmitHandler}
     >
       {!isFirst && <br />}
       <FormPiece>
@@ -101,7 +106,7 @@ const SchoolContact: React.FC<SchoolContactProps> = ({
             <Button type="default" onClick={onCancelHandler}>
               Cancel
             </Button>
-            <Button type="primary" htmlType="submit">
+            <Button type="primary" onClick={onSubmitHandler}>
               Submit
             </Button>
           </Row>

--- a/src/containers/schoolInfo/SchoolInformationForm.tsx
+++ b/src/containers/schoolInfo/SchoolInformationForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Col, Form, Input, Row, Select } from 'antd';
 import { FormTextArea } from '../../components';
 import FormContainer from '../../components/form-style/FormContainer';
@@ -25,6 +25,11 @@ const SchoolInformationForm: React.FC<SchoolInformationFormProps> = ({
 }) => {
   const [editMode, setEditMode] = useState<boolean>(!defaultSchoolInformation);
   const history = useHistory();
+  const [form] = Form.useForm()
+
+  useEffect(() => {
+    form.setFieldsValue(defaultSchoolInformation);
+  }, [form, defaultSchoolInformation]);
 
   const goPrev = () => {
     history.push('/select-school');
@@ -33,7 +38,7 @@ const SchoolInformationForm: React.FC<SchoolInformationFormProps> = ({
   return (
     <Form
       onFinish={(form: SchoolRequest) => onFinish(form, editMode)}
-      initialValues={defaultSchoolInformation}
+      form={form}
     >
       <FormContainer title="School Information">
         <Row gutter={[0, 24]}>
@@ -95,6 +100,7 @@ const SchoolInformationForm: React.FC<SchoolInformationFormProps> = ({
             text="Cancel"
             onClick={() => {
               setEditMode(false);
+              form.setFieldsValue(defaultSchoolInformation);
             }}
           />
         ) : (

--- a/src/containers/schoolInfo/SchoolInformationForm.tsx
+++ b/src/containers/schoolInfo/SchoolInformationForm.tsx
@@ -37,7 +37,7 @@ const SchoolInformationForm: React.FC<SchoolInformationFormProps> = ({
 
   return (
     <Form
-      onFinish={(form: SchoolRequest) => onFinish(form, editMode)}
+      onFinish={(req: SchoolRequest) => onFinish(req, editMode)}
       form={form}
     >
       <FormContainer title="School Information">


### PR DESCRIPTION


## Why

[clickup Ticket](https://app.clickup.com/t/1neydt6)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

On the school info and school contact forms, when the user clicks "edit", and then changes some of the info, and then clicks "cancel", the previous information is returned to the fields. 

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

Instead of using the "initialValues" prop, I'm using the "form" prop, and then updating the form to the initial values when the user clicks cancel for both of them. 

## Screenshots
<!-- Provide screenshots of any new components, styling changes, or pages. --> 
Can't really provide screenshots of any relevancy, testing it will be best way to see it lol

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 

npm start and then go to fill out a form for a school. Try to edit the school information info, and then hit cancel. the original info should be there. Do the same for the school contacts
