### PR TITLE
Cancel create user when clicking x-button

### DIFF
--- a/src/containers/userDirectory/index.tsx
+++ b/src/containers/userDirectory/index.tsx
@@ -192,7 +192,13 @@ const UserDirectory: React.FC = () => {
       {!error && (
         <Container>
           <BackButton />
-          <Modal visible={createUser} width={1000} footer={null} destroyOnClose>
+          <Modal
+            visible={createUser}
+            width={1000}
+            footer={null}
+            destroyOnClose
+            onCancel={handleOnCancelCreateUser}
+          >
             <CreateUser
               onFinish={handleOnFinishCreateUser}
               onCancel={handleOnCancelCreateUser}


### PR DESCRIPTION
## Why

[Ticket](https://app.clickup.com/t/1j85c1n)

Fix bug so the Add User popup closes when clicking the x button / outside of the config box

## This PR

Specify an onCancel property

## Verification Steps

Click add user button & click the X-button or outside of the config box to close it
