### PR TITLE
color palettes

### DIFF
--- a/src/components/form-style/FormButtons.tsx
+++ b/src/components/form-style/FormButtons.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import getColorPalette from '../../utils/colors';
 
 const FormButtonsContainer = styled.div`
   display: flex;
@@ -42,8 +43,11 @@ const FormButton: React.FC<FormButtonProps> = ({
 }) => {
   const cursor = disabled ? 'default' : 'pointer';
   const opacity = disabled ? 0.5 : 1;
-  const backgroundColor = type === 'primary' ? '#294186' : '#E3E5E5';
-  const foregroundColor = type === 'primary' ? '#FFF' : '#333';
+  const backgroundColor = getColorPalette().tertiary;
+  const foregroundColor =
+    type === 'primary'
+      ? getColorPalette().lightText
+      : getColorPalette().darkText;
   return (
     <FormButtonElement
       type={isSubmit ? 'submit' : 'button'}

--- a/src/components/form-style/FormContainer.tsx
+++ b/src/components/form-style/FormContainer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ContentContainer, SectionTitle } from '..';
 import styled from 'styled-components';
+import getColorPalette from '../../utils/colors';
 
 interface FormContainerProps {
   // title of form section
@@ -8,7 +9,7 @@ interface FormContainerProps {
 }
 
 export const Outer = styled.div`
-  background-color: #d4d9e7;
+  background-color: ${getColorPalette().secondary};
   padding: 32px 32px 32px 32px;
   border-radius: 5px;
 `;

--- a/src/components/form-style/FormPiece.tsx
+++ b/src/components/form-style/FormPiece.tsx
@@ -3,6 +3,7 @@ import { Row, Col, Typography } from 'antd';
 import { ClarifyText } from '..';
 import { DeleteOutlined } from '@ant-design/icons';
 import styled from 'styled-components';
+import getColorPalette from '../../utils/colors';
 
 type LevelOptions = 1 | 2 | 3 | 4 | 5 | undefined;
 
@@ -48,7 +49,7 @@ const BigClarify = styled(Title)`
 `;
 
 const Piece = styled.div`
-  background-color: white;
+  background-color: ${getColorPalette().background};
   border-radius: 5px;
   margin: 0px 0px 0px 0px;
 `;

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Card, Input, Typography } from 'antd';
+import getColorPalette from '../utils/colors';
 
 const { TextArea } = Input;
 const { Title, Paragraph } = Typography;
@@ -39,7 +40,7 @@ export const Container = styled(ContentContainer)`
 `;
 
 export const Outer = styled.div`
-  background-color: #d4d9e7;
+  background-color: ${getColorPalette().secondary};
   padding: 32px 32px;
   border-radius: 5px;
   margin: auto;
@@ -47,7 +48,7 @@ export const Outer = styled.div`
 
 export const Inner = styled.div`
   padding: 32px 32px 32px 32px;
-  background-color: white;
+  background-color: ${getColorPalette().background};
   border-radius: 5px;
 `;
 

--- a/src/components/navbar/NavBar.tsx
+++ b/src/components/navbar/NavBar.tsx
@@ -3,14 +3,15 @@ import { Col, Row } from 'antd';
 import styled from 'styled-components';
 import { Routes } from '../../App';
 import { Link } from 'react-router-dom';
+import getColorPalette from '../../utils/colors';
 
 const NavRow = styled(Row)`
-  background-color: #294186;
+  background-color: ${getColorPalette().primary};
 `;
 
 const HeadTitle = styled.h1`
   font-weight: bold;
-  color: white;
+  color: ${getColorPalette().headerText};
   font-size: 32px;
   margin: 0;
   padding: 16px 16px;

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -10,7 +10,7 @@ import {
 import { C4CState } from '../../store';
 import { connect } from 'react-redux';
 import { getPrivilegeLevel } from '../../auth/ducks/selectors';
-import { PRIMARY } from '../../utils/colors';
+import getColorPalette, { PRIMARY } from '../../utils/colors';
 import { Routes } from '../../App';
 
 const { Text } = Typography;
@@ -24,12 +24,12 @@ const NavBarButton = styled(Button)`
     color: inherit;
   }
   :hover {
-    color: ${PRIMARY};
+    color: ${getColorPalette().primary};
   }
 `;
 
 const ActiveNavBarButton = styled(NavBarButton)`
-  color: ${PRIMARY};
+  color: ${getColorPalette().primary};
   font-weight: 500;
 `;
 
@@ -64,7 +64,7 @@ const NavBarText = styled(Text)`
 `;
 
 const Subtitle = styled(Text)`
-  color: ${PRIMARY};
+  color: ${getColorPalette().primary};
 `;
 
 const UserContainer = styled.div`

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -10,7 +10,7 @@ import {
 import { C4CState } from '../../store';
 import { connect } from 'react-redux';
 import { getPrivilegeLevel } from '../../auth/ducks/selectors';
-import getColorPalette, { PRIMARY } from '../../utils/colors';
+import getColorPalette from '../../utils/colors';
 import { Routes } from '../../App';
 
 const { Text } = Typography;

--- a/src/components/schoolDirectory/BookLogsMenu.tsx
+++ b/src/components/schoolDirectory/BookLogsMenu.tsx
@@ -20,6 +20,7 @@ import {
   BookLogRequest,
   BookLogResponse,
 } from '../../containers/bookLogs/types';
+import getColorPalette from '../../utils/colors';
 
 const { Title } = Typography;
 
@@ -66,9 +67,9 @@ export const InlineFormContainer = styled.div`
 `;
 
 export const AddBookButton = styled(SubmitButton)`
-  background: #294186;
+  background: ${getColorPalette().primary};
   border-radius: 92px;
-  color: white;
+  color: ${getColorPalette().lightText};
   margin: 0 auto;
   margin-left: 38%;
   width: 24%;
@@ -76,18 +77,18 @@ export const AddBookButton = styled(SubmitButton)`
 `;
 
 export const CancelButton = styled(SubmitButton)`
-  background: #fff;
+  background: ${getColorPalette().lightText};
   border-radius: 92px;
-  color: #294186;
-  border: 2px solid #294186;
+  color: ${getColorPalette().primary};
+  border: 2px solid ${getColorPalette().primary};
   height: 42px;
   margin-right: 20px;
 `;
 
 export const SaveButton = styled(SubmitButton)`
-  background: #294186;
+  background: ${getColorPalette().primary};
   border-radius: 34px;
-  color: white;
+  color: ${getColorPalette().lightText};
   height: 42px;
   margin-left: 20px;
 `;
@@ -118,7 +119,10 @@ const BookLogsMenu: React.FC<BookLogsMenuProps> = ({
           date: log.date,
           id: log.id,
           notes: log.notes,
-          style: ind > added - 1 ? '#fff' : '#E6F7FF',
+          style:
+            ind > added - 1
+              ? getColorPalette().background
+              : getColorPalette().tertiary,
         };
         return styledLog;
       });

--- a/src/components/userDirectory/CreateUser.tsx
+++ b/src/components/userDirectory/CreateUser.tsx
@@ -114,24 +114,22 @@ const CreateUser: React.FC<CreateUserProps> = ({
                   </Form.Item>
                 </Col>
               </Row>
-              {update && (
-                <Row gutter={[0, 24]}>
-                  <Col flex={24}>
-                    <Form.Item
-                      name="privilegeLevel"
-                      rules={[{ required: true, message: 'Required' }]}
-                    >
-                      <Select placeholder="User's Privilege">
-                        {Object.keys(UserPrivilegeLevel).map((key: string) => (
-                          <Option key={key} value={key}>
-                            {convertEnumToRegularText(key)}
-                          </Option>
-                        ))}
-                      </Select>
-                    </Form.Item>
-                  </Col>
-                </Row>
-              )}
+              <Row gutter={[0, 24]}>
+                <Col flex={24}>
+                  <Form.Item
+                    name="privilegeLevel"
+                    rules={[{ required: true, message: 'Required' }]}
+                  >
+                    <Select placeholder="User's Privilege">
+                      {Object.keys(UserPrivilegeLevel).map((key: string) => (
+                        <Option key={key} value={key}>
+                          {convertEnumToRegularText(key)}
+                        </Option>
+                      ))}
+                    </Select>
+                  </Form.Item>
+                </Col>
+              </Row>
             </FormPiece>
           </Col>
         </Row>

--- a/src/containers/home/index.tsx
+++ b/src/containers/home/index.tsx
@@ -19,6 +19,7 @@ import { logout } from '../../auth/ducks/thunks';
 import { PrivilegeLevel } from '../../auth/ducks/types';
 import { C4CState } from '../../store';
 import { getPrivilegeLevel } from '../../auth/ducks/selectors';
+import getColorPalette from '../../utils/colors';
 
 const { Title, Paragraph } = Typography;
 
@@ -52,7 +53,7 @@ const InContain: React.FC<InContainProps> = ({
   const ContainDiv = styled.div`
     padding: 15px 20px 15px 20px;
     margin: 0px 0px ${bottomMargin} 0px;
-    background-color: white;
+    background-color: ${getColorPalette().background};
     border-radius: 5px;
     &:hover {
       cursor: pointer;

--- a/src/containers/login/index.tsx
+++ b/src/containers/login/index.tsx
@@ -15,6 +15,7 @@ import {
   UserAuthenticationReducerState,
   LoginRequest,
 } from '../../auth/ducks/types';
+import getColorPalette from '../../utils/colors';
 
 const { Paragraph } = Typography;
 
@@ -32,7 +33,7 @@ const Center = styled.div`
 const SubText = styled(Paragraph)`
   font-size: 12px;
   font-weight: 400;
-  color: #767a7d;
+  color: ${getColorPalette().subtext};
 `;
 
 type LoginProps = UserAuthenticationReducerState;

--- a/src/containers/userDirectory/index.tsx
+++ b/src/containers/userDirectory/index.tsx
@@ -13,12 +13,13 @@ import CreateUser from '../../components/userDirectory/CreateUser';
 import UserDirectoryActionMenu, {
   UserDirectoryAction,
 } from '../../components/userDirectory/UserDirectoryActionMenu';
+import getColorPalette from '../../utils/colors';
 import { UpdateUserRequest, UserResponse } from './types';
 
 const { Search } = Input;
 
 const DisabledContainer = styled.div`
-  color: red;
+  color: ${getColorPalette().disabled};
 `;
 
 const UserDirectory: React.FC = () => {

--- a/src/utils/colors.tsx
+++ b/src/utils/colors.tsx
@@ -1,2 +1,51 @@
-export const PRIMARY = '#1da57a';
+import { Countries } from './countries';
+
+export const PRIMARY = '#3BD1BC';
+export const SECONDARY = '#F88812';
+export const BACKGROUND = '#FFFFFF';
 export const LINK = '#1890ff';
+export const HEADER_TEXT = '#FFFFFF';
+
+interface HexColorPalette {
+  readonly primary: string;
+  readonly primaryDark: string;
+  readonly secondary: string;
+  readonly tertiary: string;
+  readonly background: string;
+  readonly headerText: string;
+  readonly disabled: string;
+  readonly darkText: string;
+  readonly lightText: string;
+  readonly subtext: string;
+}
+
+export default function getColorPalette(country?: string): HexColorPalette {
+  switch (country) {
+    case Countries.UNITED_STATES:
+      return {
+        primary: '#3BD1BC',
+        primaryDark: '#299283',
+        secondary: '#F88812',
+        tertiary: '#E3E5E5',
+        background: '#FFFFFF',
+        headerText: '#FFFFFF',
+        disabled: '#EB5757',
+        darkText: '#333',
+        lightText: '#FFF',
+        subtext: '#767a7d',
+      };
+    default:
+      return {
+        primary: '#3BD1BC',
+        primaryDark: '#299283',
+        secondary: '#F88812',
+        tertiary: '#E3E5E5',
+        background: '#FFFFFF',
+        headerText: '#FFFFFF',
+        disabled: '#EB5757',
+        darkText: '#333',
+        lightText: '#FFF',
+        subtext: '#767a7d',
+      };
+  }
+}

--- a/src/utils/colors.tsx
+++ b/src/utils/colors.tsx
@@ -1,11 +1,5 @@
 import { Countries } from './countries';
 
-export const PRIMARY = '#3BD1BC';
-export const SECONDARY = '#F88812';
-export const BACKGROUND = '#FFFFFF';
-export const LINK = '#1890ff';
-export const HEADER_TEXT = '#FFFFFF';
-
 interface HexColorPalette {
   readonly primary: string;
   readonly primaryDark: string;
@@ -21,10 +15,11 @@ interface HexColorPalette {
 
 export default function getColorPalette(country?: string): HexColorPalette {
   switch (country) {
+    // example of how to create a country specific country palette
     case Countries.UNITED_STATES:
       return {
-        primary: '#3BD1BC',
-        primaryDark: '#299283',
+        primary: '#3BD1BC', // these are the same as in the default palette, but you could
+        primaryDark: '#299283', // change them to red white and blue if you wanted
         secondary: '#F88812',
         tertiary: '#E3E5E5',
         background: '#FFFFFF',


### PR DESCRIPTION
## Why
https://app.clickup.com/t/2b92xr6 

## This PR
Create and implement reusable color palettes.

Most new code is in `src/utils/colors.tsx`
- Added new interface `HexColorPalette`, with fields to fill in for different color palettes (main colors are primary (teal), tertiary (orange), and second (light gray), with some others like lightText (white) and darkText (dark gray))
- Added function `getColorPalette` which takes in an optional argument of a country (using the enum type from `src/utils/countries.tsx`), or if no argument is given uses the default color palette
- (Note: I added an example of how this would work using `Countries.UNITED_STATES` and just left the colors as default)

Colors can be called else in react components using `getColorPalette().primary` (returns HEX code), with primary being whichever color in the palette that you want, and optionally including an argument for country.

## Screenshots
<img width="1365" alt="Screen Shot 2022-02-13 at 4 10 13 PM" src="https://user-images.githubusercontent.com/55663537/153775174-120beb5e-e070-44f4-8b9d-592b7b86d756.png">
<img width="1365" alt="Screen Shot 2022-02-13 at 4 22 05 PM" src="https://user-images.githubusercontent.com/55663537/153775586-104eb202-1e30-417b-ad1c-38b6e8444e1f.png">
<img width="1365" alt="Screen Shot 2022-02-13 at 4 22 35 PM" src="https://user-images.githubusercontent.com/55663537/153775600-3453b3a9-0695-4786-a6dc-ede350e58440.png">


## Verification Steps
Clicking through frontend quickly – I don't think I caught every instance of color calls (and there are some antD override things happening that need to be fixed), but I added enough to get a sense of what the color palette looks like.
