### PR TITLE
remove extra check that stops user privilege select input from appearing

### DIFF
--- a/src/components/userDirectory/CreateUser.tsx
+++ b/src/components/userDirectory/CreateUser.tsx
@@ -114,24 +114,22 @@ const CreateUser: React.FC<CreateUserProps> = ({
                   </Form.Item>
                 </Col>
               </Row>
-              {update && (
-                <Row gutter={[0, 24]}>
-                  <Col flex={24}>
-                    <Form.Item
-                      name="privilegeLevel"
-                      rules={[{ required: true, message: 'Required' }]}
-                    >
-                      <Select placeholder="User's Privilege">
-                        {Object.keys(UserPrivilegeLevel).map((key: string) => (
-                          <Option key={key} value={key}>
-                            {convertEnumToRegularText(key)}
-                          </Option>
-                        ))}
-                      </Select>
-                    </Form.Item>
-                  </Col>
-                </Row>
-              )}
+              <Row gutter={[0, 24]}>
+                <Col flex={24}>
+                  <Form.Item
+                    name="privilegeLevel"
+                    rules={[{ required: true, message: 'Required' }]}
+                  >
+                    <Select placeholder="User's Privilege">
+                      {Object.keys(UserPrivilegeLevel).map((key: string) => (
+                        <Option key={key} value={key}>
+                          {convertEnumToRegularText(key)}
+                        </Option>
+                      ))}
+                    </Select>
+                  </Form.Item>
+                </Col>
+              </Row>
             </FormPiece>
           </Col>
         </Row>


### PR DESCRIPTION
## Why

## This PR

see this slack comment for details (copied below): https://c4cneuteams.slack.com/archives/C01ARU56B4N/p1644164501820399?thread_ts=1644019125.476429&cid=C01ARU56B4N

I was looking into my ticket but was little confused about what I was supposed to add to the existing code.  It looks like [there already is a select dropdown for user role in our code](https://github.com/Code-4-Community/hands-across-the-sea-frontend/blob/staging/src/components/userDirectory/CreateUser.tsx#L117-L134), it’s just not being displayed because of some property update (not sure exactly what this represents).  I can easily just remove that clause and it’ll show up (see screenshot), but I’m a little confused about whether that’s what should be done here?  If anyone is familiar with this component and the CreateUserProps type I’d be happy to pair sometime to try to understand what’s going on!

## Screenshots

![image](https://user-images.githubusercontent.com/55663537/155897882-f9d74229-d625-47bf-9e84-a17c66544aa2.png)

