### PR TITLE
Update front end when deleting a school

### DIFF
--- a/src/containers/schoolDirectory/index.tsx
+++ b/src/containers/schoolDirectory/index.tsx
@@ -52,7 +52,7 @@ const SchoolDirectory: React.FC = () => {
   >(undefined);
 
   const queryClient = useQueryClient();
-  const { isLoading, error, data, refetch } = useQuery(
+  const { isLoading, error, data, refetch, isRefetching } = useQuery(
     'schools',
     protectedApiClient.getAllSchools,
   );
@@ -334,7 +334,7 @@ const SchoolDirectory: React.FC = () => {
                   : undefined
               }
               columns={columns}
-              loading={isLoading}
+              loading={isLoading || isRefetching}
             />
           </Outer>
         </Container>

--- a/src/containers/schoolDirectory/index.tsx
+++ b/src/containers/schoolDirectory/index.tsx
@@ -1,7 +1,7 @@
 import { Button, Col, Input, message, Modal, Row, Table } from 'antd';
 import { ColumnType } from 'antd/lib/table';
 import moment from 'moment';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useQuery, useQueryClient } from 'react-query';
 import protectedApiClient from '../../api/protectedApiClient';
 import { DirectoryTitle } from '../../components';
@@ -52,10 +52,14 @@ const SchoolDirectory: React.FC = () => {
   >(undefined);
 
   const queryClient = useQueryClient();
-  const { isLoading, error, data } = useQuery(
+  const { isLoading, error, data, refetch } = useQuery(
     'schools',
     protectedApiClient.getAllSchools,
   );
+
+  useEffect(() => {
+    refetch();
+  }, [updateSchoolList]);
 
   // handles submitting create a school form
   const handleOnFinishCreateSchool = async (

--- a/src/containers/schoolDirectory/index.tsx
+++ b/src/containers/schoolDirectory/index.tsx
@@ -1,7 +1,7 @@
 import { Button, Col, Input, message, Modal, Row, Table } from 'antd';
 import { ColumnType } from 'antd/lib/table';
 import moment from 'moment';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useQuery, useQueryClient } from 'react-query';
 import protectedApiClient from '../../api/protectedApiClient';
 import { DirectoryTitle } from '../../components';
@@ -56,10 +56,6 @@ const SchoolDirectory: React.FC = () => {
     'schools',
     protectedApiClient.getAllSchools,
   );
-
-  useEffect(() => {
-    refetch();
-  }, [updateSchoolList]);
 
   // handles submitting create a school form
   const handleOnFinishCreateSchool = async (
@@ -207,6 +203,7 @@ const SchoolDirectory: React.FC = () => {
       } else if (key === SchoolDirectoryAction.DELETE) {
         await protectedApiClient.deleteSchool(school.id);
         setUpdateSchoolList(!updateSchoolList);
+        await refetch();
       } else if (key === SchoolDirectoryAction.BOOKS) {
         queryClient.invalidateQueries(['bookLogs', school.id]);
         setBookLogsSchool({


### PR DESCRIPTION
## Why

[Ticket](https://app.clickup.com/t/24n9byf)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
- Refetches the school list data to display on the front end whenever the school list is updated (aka when `updateSchoolList` changes, which occurs when creating or deleting a school)

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
- uses the `refetch` function from `UseQuery` and calls this when `updateSchoolList` changes
- uses the `isRefetching` property for loading spinner

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
- Previously when a school was deleted, it wasn't immediately reflected in the front-end until a full-page refresh, which re-fetched the data / list of all schools. I created/deleted several schools to verify that the school being deleted is immediately deleted. I also tested it with the 3G/Slow setting to make sure the loading spinner appears
