### PR TITLE
tiny color fix (primary button)

### DIFF
--- a/src/components/form-style/FormButtons.tsx
+++ b/src/components/form-style/FormButtons.tsx
@@ -43,7 +43,8 @@ const FormButton: React.FC<FormButtonProps> = ({
 }) => {
   const cursor = disabled ? 'default' : 'pointer';
   const opacity = disabled ? 0.5 : 1;
-  const backgroundColor = getColorPalette().tertiary;
+  const backgroundColor =
+    type === 'primary' ? getColorPalette().primary : getColorPalette().tertiary;
   const foregroundColor =
     type === 'primary'
       ? getColorPalette().lightText


### PR DESCRIPTION
## Why
fix coloring for primary buttons (used to be grey with white text and looked rly bad)

## Screenshots
<img width="647" alt="Screen Shot 2022-03-06 at 2 36 47 PM" src="https://user-images.githubusercontent.com/55663537/156939240-f9957302-a92f-4e23-bb72-3baa9611b77a.png">
<img width="1170" alt="Screen Shot 2022-03-06 at 2 37 17 PM" src="https://user-images.githubusercontent.com/55663537/156939256-0815e845-918c-460f-862f-070b36a00b49.png">
