### PR TITLE
csv download appears to be working

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "antd": "^4.12.3",
         "axios": "^0.21.4",
         "craco-antd": "^1.19.0",
+        "js-file-download": "^0.4.12",
         "lodash": "^4.17.21",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
@@ -13840,6 +13841,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/js-file-download": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/js-file-download/-/js-file-download-0.4.12.tgz",
+      "integrity": "sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg=="
     },
     "node_modules/js-sha3": {
       "version": "0.8.0",
@@ -34892,6 +34898,11 @@
           }
         }
       }
+    },
+    "js-file-download": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/js-file-download/-/js-file-download-0.4.12.tgz",
+      "integrity": "sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg=="
     },
     "js-sha3": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "antd": "^4.12.3",
     "axios": "^0.21.4",
     "craco-antd": "^1.19.0",
+    "js-file-download": "^0.4.12",
     "lodash": "^4.17.21",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",

--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -133,6 +133,9 @@ export interface ProtectedApiClient {
   readonly getTotalMetrics: () => Promise<TotalMetric>;
   readonly getCountryMetrics: (country: string) => Promise<CountryMetric>;
   readonly getSchoolMetrics: (schoolId: number) => Promise<SchoolMetric>;
+
+  readonly getReportWithLibraryCsv: (reportId: number) => Promise<string>;
+  readonly getReportWithoutLibraryCsv: (reportId: number) => Promise<string>;
 }
 
 export enum ProtectedApiClientRoutes {
@@ -148,6 +151,8 @@ export enum ProtectedApiClientRoutes {
   PAST_SUBMISSIONS_SCHOOLS = '/api/v1/protected/schools/reports/users',
   DATA_VIS = '/api/v1/protected/data',
   COUNTRIES = '/api/v1/protected/countries/',
+  REPORT_WITH_LIBRARY_CSV = '/api/v1/protected/schools/reports/with-library',
+  REPORT_WITHOUT_LIBRARY_CSV = '/api/v1/protected/schools/reports/without-library',
 }
 
 export type WithCount<T> = T & {
@@ -446,6 +451,18 @@ const getSchoolMetrics = (schoolId: number): Promise<SchoolMetric> => {
   ).then((res) => res.data);
 };
 
+const getReportWithLibraryCsv = (reportId: number): Promise<string> => {
+  return AppAxiosInstance.get(
+    `${ProtectedApiClientRoutes.REPORT_WITH_LIBRARY_CSV}/${reportId}`,
+  ).then((res) => res.data);
+};
+
+const getReportWithoutLibraryCsv = (reportId: number): Promise<string> => {
+  return AppAxiosInstance.get(
+    `${ProtectedApiClientRoutes.REPORT_WITHOUT_LIBRARY_CSV}/${reportId}`,
+  ).then((res) => res.data);
+};
+
 const Client: ProtectedApiClient = Object.freeze({
   changePassword,
   createSchool,
@@ -478,6 +495,8 @@ const Client: ProtectedApiClient = Object.freeze({
   getTotalMetrics,
   getCountryMetrics,
   getSchoolMetrics,
+  getReportWithLibraryCsv,
+  getReportWithoutLibraryCsv,
 });
 
 export default Client;

--- a/src/containers/pastSubmissionsReports/PastSubmissionActions.tsx
+++ b/src/containers/pastSubmissionsReports/PastSubmissionActions.tsx
@@ -39,7 +39,7 @@ const PastSubmissionActions: React.FC<PastSubmissionActionsProps> = ({
   const downloadReport = () => {
     console.log(data);
     if (data) {
-      fileDownload(data, 'reportData.csv');
+      fileDownload(data, `$Report${report.schoolName}-${report.id}.csv`);
     }
   };
 

--- a/src/containers/pastSubmissionsReports/PastSubmissionActions.tsx
+++ b/src/containers/pastSubmissionsReports/PastSubmissionActions.tsx
@@ -37,7 +37,6 @@ const PastSubmissionActions: React.FC<PastSubmissionActionsProps> = ({
   );
 
   const downloadReport = () => {
-    console.log(data);
     if (data) {
       fileDownload(data, `Report${report.schoolName}-${report.id}.csv`);
     }

--- a/src/containers/pastSubmissionsReports/PastSubmissionActions.tsx
+++ b/src/containers/pastSubmissionsReports/PastSubmissionActions.tsx
@@ -1,13 +1,20 @@
-import { Button } from 'antd';
+import { Button, Dropdown, Menu } from 'antd';
 import React from 'react';
 import { useDispatch } from 'react-redux';
+import { useQuery } from 'react-query';
 import { useHistory } from 'react-router-dom';
 import { Routes } from '../../App';
 import { LibraryReportResponse } from '../library-report/ducks/types';
 import { setActiveReport } from './ducks/actions';
+import protectedApiClient from '../../api/protectedApiClient';
+import fileDownload from 'js-file-download';
 
 interface PastSubmissionActionsProps {
   report: LibraryReportResponse;
+}
+
+interface EventProps {
+  key: string;
 }
 
 const PastSubmissionActions: React.FC<PastSubmissionActionsProps> = ({
@@ -21,11 +28,41 @@ const PastSubmissionActions: React.FC<PastSubmissionActionsProps> = ({
     history.push(Routes.EDIT_LIBRARY_REPORT);
   };
 
+  const { data } = useQuery(
+    'reports',
+    () => protectedApiClient.getReportWithLibraryCsv(report.id),
+    {
+      enabled: report.id !== undefined,
+    },
+  );
+
+  const downloadReport = () => {
+    console.log(data);
+    if (data) {
+      fileDownload(data, 'reportData.csv');
+    }
+  };
+
+  const handleMenuClick = (e: EventProps) => {
+    if (e.key === '1') {
+      viewReport();
+    } else if (e.key === '2') {
+      downloadReport();
+    }
+  };
+
+  const menu = (
+    <Menu onClick={handleMenuClick}>
+      <Menu.Item key="1">View/Edit</Menu.Item>
+      <Menu.Item key="2">Download as CSV</Menu.Item>
+    </Menu>
+  );
+
   return (
     <div>
-      <Button type="primary" onClick={viewReport}>
-        View/Edit
-      </Button>
+      <Dropdown overlay={menu}>
+        <Button type="primary">Actions</Button>
+      </Dropdown>
     </div>
   );
 };

--- a/src/containers/pastSubmissionsReports/PastSubmissionActions.tsx
+++ b/src/containers/pastSubmissionsReports/PastSubmissionActions.tsx
@@ -39,7 +39,7 @@ const PastSubmissionActions: React.FC<PastSubmissionActionsProps> = ({
   const downloadReport = () => {
     console.log(data);
     if (data) {
-      fileDownload(data, `$Report${report.schoolName}-${report.id}.csv`);
+      fileDownload(data, `Report${report.schoolName}-${report.id}.csv`);
     }
   };
 


### PR DESCRIPTION
## This PR
Add a button to download a report as a csv.  Uses the Get Report As CSV API endpoint (https://docs.c4cneu.com/hats/api-spec-school-report/#get-report-as-csv).  Pretty sketchy (apparently it is very bad practice to download a file directly from frontend) but it appears to be working

## Screenshots
<img width="1053" alt="Screen Shot 2022-03-27 at 2 45 49 PM" src="https://user-images.githubusercontent.com/55663537/160295996-ff0967f6-ba98-47b0-be22-61eac2e6d3f6.png">

## Verification Steps
tested locally once and it worked