### PR TITLE
Added back button to edit library report page

### DIFF
--- a/src/containers/pastSubmissionsReports/EditLibraryReport.tsx
+++ b/src/containers/pastSubmissionsReports/EditLibraryReport.tsx
@@ -35,6 +35,10 @@ const EditLibraryReport: React.FC = () => {
   const isYesReport = report && report.libraryStatus === 'EXISTS';
   const [editMode, setEditMode] = useState(false);
 
+  const goPrev = () => {
+    history.push('/past-submissions-reports');
+  };
+
   useEffect(() => {
     if (!report) {
       history.replace(Routes.PAST_SUBMISSIONS_REPORTS);
@@ -73,6 +77,7 @@ const EditLibraryReport: React.FC = () => {
 
   const buttons = (
     <FormButtons>
+      <FormButtons.Button text="Back" type="secondary" onClick={goPrev} />
       {editMode ? (
         <>
           <FormButtons.Button


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/XXXXXXXX/pulses/XXXXXXX)

Trello Card https://trello.com/c/CbySOxnr/9-add-back-button-to-edit-library-report-page

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

## This PR

Added a back button to the edit library report page in "Form History". Modeled it after the edit report page in "Fill out a Form".

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 
![Screen Shot 2022-11-06 at 4 29 00 PM](https://user-images.githubusercontent.com/77256794/200196132-bcabf437-2560-4381-964d-16a20717bd4c.png)

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
