### PR TITLE
Added selector to choose different graph types in Visualization tab

### DIFF
--- a/src/containers/dataVisualization/metrics/VisualizationMetrics.tsx
+++ b/src/containers/dataVisualization/metrics/VisualizationMetrics.tsx
@@ -90,7 +90,7 @@ const VisualizationMetrics: React.FC = () => {
             },
           }}
       />
-    } else if (selectedChartType == "PIE") {
+    } else if (selectedChartType === "PIE") {
       return <Pie 
           {...config}
           angleField='count'

--- a/src/containers/dataVisualization/metrics/VisualizationMetrics.tsx
+++ b/src/containers/dataVisualization/metrics/VisualizationMetrics.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Col, Row } from 'antd';
-import { Line, Column, Area, Pie } from '@ant-design/plots';
+import { Line, Column, Area } from '@ant-design/plots';
 import { useQuery } from 'react-query';
 import protectedApiClient from '../../../api/protectedApiClient';
 import moment from 'moment';
@@ -11,8 +11,7 @@ import FormItemDropdown from '../../../components/form-style/FormItemDropdown';
 enum CHART_TYPES {
   LINE = "Line",
   COLUMN = "Column",
-  AREA = "Area",
-  PIE = "Pie"
+  AREA = "Area"
 }
 
 const VisualizationMetrics: React.FC = () => {
@@ -84,17 +83,6 @@ const VisualizationMetrics: React.FC = () => {
     } else if (selectedChartType === "AREA") {
       return <Area 
           {...config}
-          tooltip={{
-            formatter: (record) => {
-              return { name: 'Number of Books', value: record.count };
-            },
-          }}
-      />
-    } else if (selectedChartType === "PIE") {
-      return <Pie 
-          {...config}
-          angleField='count'
-          colorField='date'
           tooltip={{
             formatter: (record) => {
               return { name: 'Number of Books', value: record.count };

--- a/src/containers/dataVisualization/metrics/VisualizationMetrics.tsx
+++ b/src/containers/dataVisualization/metrics/VisualizationMetrics.tsx
@@ -1,11 +1,24 @@
-import React from 'react';
-import { Row } from 'antd';
-import { Line } from '@ant-design/plots';
+import React, { useState } from 'react';
+import { Col, Row } from 'antd';
+import { Line, Column, Area, Pie } from '@ant-design/plots';
 import { useQuery } from 'react-query';
 import protectedApiClient from '../../../api/protectedApiClient';
 import moment from 'moment';
+import { StyledRow } from '../../../components/dataVisualization';
+import FormItemDropdown from '../../../components/form-style/FormItemDropdown';
+
+
+enum CHART_TYPES {
+  LINE = "Line",
+  COLUMN = "Column",
+  AREA = "Area",
+  PIE = "Pie"
+}
 
 const VisualizationMetrics: React.FC = () => {
+
+  const [selectedChartType, setSelectedChartType] = useState<string>("LINE");
+
   function formatDate(date: string) {
     return moment(date).format('MM/DD/YYYY');
   }
@@ -36,31 +49,85 @@ const VisualizationMetrics: React.FC = () => {
     getAggregatedData,
   );
 
-  return (
-    <Row justify="center">
-      {isLoading && <p>Loading visualization...</p>}
-      {error && <p>An error occurred loading visualization</p>}
-      {data && (
-        <Line
-          width={750}
-          data={data}
-          padding="auto"
-          xField="date"
-          yField="count"
-          xAxis={{
-            title: { text: 'Time' },
-          }}
-          yAxis={{
-            title: { text: 'Number of Books' },
-          }}
+  const displayChart = () => {
+    const config = {
+      width: 750,
+      data: data || [],
+      xAxis: {
+        title: { text: 'Time'}
+      },
+      yAxis: {
+        title: { text: 'Number of Books '}
+      },
+      xField: "date",
+      yField: "count"
+    }
+
+    if (selectedChartType === "LINE") {
+      return <Line 
+          {...config}
           tooltip={{
             formatter: (record) => {
               return { name: 'Number of Books', value: record.count };
             },
           }}
-        />
-      )}
-    </Row>
+      />
+    } else if (selectedChartType === "COLUMN") {
+      return <Column 
+          {...config}
+          tooltip={{
+            formatter: (record) => {
+              return { name: 'Number of Books', value: record.count };
+            },
+          }}
+      />
+    } else if (selectedChartType === "AREA") {
+      return <Area 
+          {...config}
+          tooltip={{
+            formatter: (record) => {
+              return { name: 'Number of Books', value: record.count };
+            },
+          }}
+      />
+    } else if (selectedChartType == "PIE") {
+      return <Pie 
+          {...config}
+          angleField='count'
+          colorField='date'
+          tooltip={{
+            formatter: (record) => {
+              return { name: 'Number of Books', value: record.count };
+            },
+          }}
+      />
+    }
+  }
+
+  return (
+    <>
+      <StyledRow justify="center">
+        <Col span={16}>
+          <FormItemDropdown
+            clarifyText={
+              'Select Graph Type'
+            }
+            optionsEnum={CHART_TYPES}
+            name={'chartType'}
+            text={'Line'}
+            disabled={false}
+            required={true}
+            onChange={(value) => setSelectedChartType(value)}
+          />
+        </Col>
+      </StyledRow>
+    
+      <Row justify="center">
+        {isLoading && <p>Loading visualization...</p>}
+        {error && <p>An error occurred loading visualization</p>}
+        {data && displayChart()}
+      </Row>
+    </>
   );
 };
 


### PR DESCRIPTION
## Why

[Trello Card](https://trello.com/c/7t3MuUSO/18-data-viz-add-selector-for-graph-type-visual-display)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

Allows user to choose between viewing a line, column, area, or pie graph

* I don't know if it makes sense to have the pie chart with the current axis (date and # of books) but it might work better once the axis can be changed

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

## Screenshots

![Screen Shot 2022-12-01 at 4 47 46 PM](https://user-images.githubusercontent.com/77256794/205165912-f613d1ea-d822-47e4-989a-4f3321fe32d1.png)

![Screen Shot 2022-12-01 at 4 48 03 PM](https://user-images.githubusercontent.com/77256794/205165968-4ab205f8-b201-4ca1-bded-625e89df5289.png)

![Screen Shot 2022-12-01 at 4 48 17 PM](https://user-images.githubusercontent.com/77256794/205166005-85c68d8c-78cc-4b71-8314-0b3002ae615c.png)



<!-- Provide screenshots of any new components, styling changes, or pages. --> 

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 